### PR TITLE
Refactor chemistry application instances

### DIFF
--- a/examples/advanced_estimates.py
+++ b/examples/advanced_estimates.py
@@ -7,12 +7,7 @@ from benchq import BasicArchitectureModel
 from benchq.algorithms import get_qsp_program
 from benchq.problem_ingestion import (
     generate_jw_qubit_hamiltonian_from_mol_data,
-    generate_mol_data_for_h_chain,
-)
-from benchq.problem_ingestion.molecule_instance_generation import (
-    generate_mean_field_object_from_molecule,
-    generate_mol_data_for_h_chain,
-    generate_mol_object_for_h_chain,
+    generate_hydrogen_chain_instance,
 )
 from benchq.resource_estimation import get_qpe_resource_estimates_from_mean_field_object
 
@@ -39,20 +34,9 @@ def print_re(resource_estimates, label):
 
 
 def get_of_resource_estimates(n_hydrogens):
-    mol_object = generate_mol_object_for_h_chain(n_hydrogens)
-    ao_list = [
-        "H 1s",
-        "H 2s",
-        # "H 2p",
-        # "H 3s",
-        # "H 3p",
-    ] * n_hydrogens
-    mean_field_object = generate_mean_field_object_from_molecule(
-        mol_object,
-        ao_list,
-        # minao="6-31g",
-        minao="sto-3g",
-    )
+    mean_field_object = generate_hydrogen_chain_instance(
+        n_hydrogens
+    ).get_avas_meanfield_object()
 
     # Running resource estimation with OpenFermion tools
 
@@ -82,7 +66,7 @@ def main():
         # TA 1 part: specify the core computational capability
         start = time.time()
         # Generate instance
-        mol_data = generate_mol_data_for_h_chain(n_hydrogens)
+        mol_data = generate_hydrogen_chain_instance(n_hydrogens).get_molecular_data()
 
         # Convert instance to core computational problem instance
         operator = generate_jw_qubit_hamiltonian_from_mol_data(mol_data)
@@ -92,6 +76,7 @@ def main():
         ### OPENFERMION ESTIMATES
         start = time.time()
         of_resource_estimates = get_of_resource_estimates(n_hydrogens)
+        print(of_resource_estimates)
         end = time.time()
         print("OF resource estimation took:", end - start, "seconds")
         ### END OPENFERMION ESTIMATES

--- a/examples/advanced_estimates.py
+++ b/examples/advanced_estimates.py
@@ -6,8 +6,8 @@ import time
 from benchq import BasicArchitectureModel
 from benchq.algorithms import get_qsp_program
 from benchq.problem_ingestion import (
-    generate_jw_qubit_hamiltonian_from_mol_data,
     generate_hydrogen_chain_instance,
+    generate_jw_qubit_hamiltonian_from_mol_data,
 )
 from benchq.resource_estimation import get_qpe_resource_estimates_from_mean_field_object
 

--- a/examples/advanced_estimates.py
+++ b/examples/advanced_estimates.py
@@ -36,7 +36,7 @@ def print_re(resource_estimates, label):
 def get_of_resource_estimates(n_hydrogens):
     mean_field_object = generate_hydrogen_chain_instance(
         n_hydrogens
-    ).get_avas_meanfield_object()
+    ).get_active_space_meanfield_object()
 
     # Running resource estimation with OpenFermion tools
 

--- a/examples/h_chain_trotter.py
+++ b/examples/h_chain_trotter.py
@@ -32,7 +32,7 @@ def main():
 
         begtime = time.time()
         start = begtime
-        mol_data = generate_hydrogen_chain_instance(n_hydrogens)
+        mol_data = generate_hydrogen_chain_instance(n_hydrogens).get_molecular_data()
         print("Generate instance:", time.time() - start)
 
         # Convert instance to core computational problem instance

--- a/examples/h_chain_trotter.py
+++ b/examples/h_chain_trotter.py
@@ -18,8 +18,8 @@ import time
 from benchq import BasicArchitectureModel
 from benchq.algorithms import get_trotter_program
 from benchq.problem_ingestion import (
-    generate_jw_qubit_hamiltonian_from_mol_data,
     generate_hydrogen_chain_instance,
+    generate_jw_qubit_hamiltonian_from_mol_data,
 )
 from benchq.resource_estimation.graph_compilation import (
     get_resource_estimations_for_program,

--- a/examples/h_chain_trotter.py
+++ b/examples/h_chain_trotter.py
@@ -17,10 +17,9 @@ import time
 
 from benchq import BasicArchitectureModel
 from benchq.algorithms import get_trotter_program
-from benchq.compilation import get_algorithmic_graph, pyliqtr_transpile_to_clifford_t
 from benchq.problem_ingestion import (
     generate_jw_qubit_hamiltonian_from_mol_data,
-    generate_mol_data_for_h_chain,
+    generate_hydrogen_chain_instance,
 )
 from benchq.resource_estimation.graph_compilation import (
     get_resource_estimations_for_program,
@@ -33,7 +32,7 @@ def main():
 
         begtime = time.time()
         start = begtime
-        mol_data = generate_mol_data_for_h_chain(n_hydrogens)
+        mol_data = generate_hydrogen_chain_instance(n_hydrogens)
         print("Generate instance:", time.time() - start)
 
         # Convert instance to core computational problem instance

--- a/examples/orquestra/hydrogen_demo/defs.py
+++ b/examples/orquestra/hydrogen_demo/defs.py
@@ -3,9 +3,9 @@ Workflow & task defs.
 
 To run this on Orquestra see the ``run.py`` script in the same directory.
 """
-from orquestra import sdk
-
 import time
+
+from orquestra import sdk
 from orquestra.quantum.evolution import time_evolution
 
 from benchq import BasicArchitectureModel

--- a/examples/qsp_vlasov.py
+++ b/examples/qsp_vlasov.py
@@ -17,6 +17,8 @@ import logging
 import time
 
 import numpy as np
+from pyLIQTR.QSP import gen_qsp as qspFuncs
+
 from benchq import BasicArchitectureModel
 from benchq.algorithms import get_qsp_circuit
 from benchq.compilation import get_algorithmic_graph, pyliqtr_transpile_to_clifford_t
@@ -24,7 +26,6 @@ from benchq.problem_ingestion import get_vlasov_hamiltonian
 from benchq.resource_estimation.graph_compilation import (
     get_resource_estimations_for_graph,
 )
-from pyLIQTR.QSP import gen_qsp as qspFuncs
 
 
 def main():

--- a/src/benchq/problem_ingestion/__init__.py
+++ b/src/benchq/problem_ingestion/__init__.py
@@ -5,5 +5,10 @@ from .hamiltonian_generation import (
     generate_fermi_hubbard_jw_qubit_hamiltonian,
     generate_jw_qubit_hamiltonian_from_mol_data,
 )
-from .molecule_instance_generation import generate_hydrogen_chain_instance
+from .molecule_instance_generation import (
+    generate_hydrogen_chain_instance,
+    ChemistryApplicationInstance,
+    WATER_MOLECULE,
+    CYCLIC_OZONE_MOLECULE,
+)
 from .vlasov import get_vlasov_hamiltonian

--- a/src/benchq/problem_ingestion/__init__.py
+++ b/src/benchq/problem_ingestion/__init__.py
@@ -5,5 +5,5 @@ from .hamiltonian_generation import (
     generate_fermi_hubbard_jw_qubit_hamiltonian,
     generate_jw_qubit_hamiltonian_from_mol_data,
 )
-from .molecule_instance_generation import generate_mol_data_for_h_chain
+from .molecule_instance_generation import generate_hydrogen_chain_instance
 from .vlasov import get_vlasov_hamiltonian

--- a/src/benchq/problem_ingestion/__init__.py
+++ b/src/benchq/problem_ingestion/__init__.py
@@ -6,9 +6,9 @@ from .hamiltonian_generation import (
     generate_jw_qubit_hamiltonian_from_mol_data,
 )
 from .molecule_instance_generation import (
-    generate_hydrogen_chain_instance,
-    ChemistryApplicationInstance,
-    WATER_MOLECULE,
     CYCLIC_OZONE_MOLECULE,
+    WATER_MOLECULE,
+    ChemistryApplicationInstance,
+    generate_hydrogen_chain_instance,
 )
 from .vlasov import get_vlasov_hamiltonian

--- a/src/benchq/problem_ingestion/hamiltonian_generation.py
+++ b/src/benchq/problem_ingestion/hamiltonian_generation.py
@@ -39,7 +39,7 @@ def generate_jw_qubit_hamiltonian_from_mol_data(
     molecular_data, occupied_indices=None, active_indices=None
 ) -> PauliSum:
 
-    hamiltonian = molecular_data.get_molecular_hamiltonian(
+    hamiltonian = molecular_data.get_active_space_hamiltonian(
         occupied_indices=occupied_indices, active_indices=active_indices
     )
 

--- a/src/benchq/problem_ingestion/hamiltonian_generation.py
+++ b/src/benchq/problem_ingestion/hamiltonian_generation.py
@@ -1,17 +1,11 @@
 ################################################################################
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
-import random
-from itertools import combinations
-from typing import Tuple
-
-import networkx as nx
 import openfermion as of
-from openfermionpyscf import generate_molecular_hamiltonian
 from orquestra.integrations.cirq.conversions._openfermion_conversions import (
     from_openfermion,
 )
-from orquestra.quantum.operators import PauliSum, PauliTerm
+from orquestra.quantum.operators import PauliSum
 
 # TODO: export openfermion to cirq
 ### General generators

--- a/src/benchq/problem_ingestion/molecule_instance_generation.py
+++ b/src/benchq/problem_ingestion/molecule_instance_generation.py
@@ -26,13 +26,13 @@ class ChemistryApplicationInstance:
     Atomic Valence Active Space (AVAS) or by specifying the indices of the occupied and
     active orbitals.
 
-    Attributes:
+    Args:
         geometry: A list of tuples of the form (atom, (x, y, z)) where atom is the
-            atom type and (x, y, z) are the coordinates of the atom.
+            atom type and (x, y, z) are the coordinates of the atom in Angstroms.
         basis: The basis set to use for the calculation.
         multiplicity: The spin multiplicity of the molecule.
         charge: The charge of the molecule.
-        avas_atomic_orbitals: A list of atomic orbitals to use for  (AVAS).
+        avas_atomic_orbitals: A list of atomic orbitals to use for (AVAS).
         avas_minao: The minimum active orbital to use for AVAS.
         occupied_indices: A list of molecular orbitals not in the active space that
             should be assumed to be fully occupied.
@@ -49,7 +49,8 @@ class ChemistryApplicationInstance:
     active_indices: Optional[Iterable[int]] = None
 
     def get_molecular_data(self) -> PyscfMolecularData:
-        """Generates a molecular data object from the instance data."""
+        """Run an SCF calculation using PySCF and return the results as a MolecularData
+        object."""
         return run_pyscf(
             MolecularData(
                 self.geometry,
@@ -60,7 +61,8 @@ class ChemistryApplicationInstance:
         )
 
     def get_active_space_hamiltonian(self) -> openfermion.InteractionOperator:
-        """Generates an interaction operator from the instance data."""
+        """Generate the fermionic Hamiltonian corresponding to the instance's
+        active space."""
         if self.avas_atomic_orbitals or self.avas_minao:
             raise ValueError(
                 "Generating the active space Hamiltonian for application instances"
@@ -72,7 +74,8 @@ class ChemistryApplicationInstance:
         )
 
     def get_active_space_meanfield_object(self) -> scf.hf.SCF:
-        """Generates a meanfield object from the instance data."""
+        """Run an SCF calculation using PySCF and return the results as a meanfield
+        object."""
         if self.active_indices or self.occupied_indices:
             raise ValueError(
                 "Generating the meanfield object for application instances with"
@@ -90,6 +93,14 @@ def truncate_with_avas(
     ao_list: Optional[Iterable[str]] = None,
     minao: Optional[str] = None,
 ):
+    """Truncates a meanfield object to a specific active space that captures the
+    essential chemistry.
+
+    Args:
+        mean_field_object: The meanfield object to be truncated.
+        ao_list: A list of atomic orbitals to use for AVAS.
+        minao: The minimum active orbital to use for AVAS.
+    """
     mean_field_object.verbose = 4
     mean_field_object.kernel()  # run the SCF
 
@@ -114,6 +125,13 @@ def generate_hydrogen_chain_instance(
     basis: str = "6-31g",
     bond_distance: float = 1.3,
 ) -> ChemistryApplicationInstance:
+    """Generate a hydrogen chain application instance.
+
+    Args:
+        number_of_hydrogens: The number of hydrogen atoms in the chain.
+        basis: The basis set to use for the calculation.
+        bond_distance: The distance between the hydrogen atoms (Angstrom).
+    """
     return ChemistryApplicationInstance(
         geometry=[("H", (0, 0, i * bond_distance)) for i in range(number_of_hydrogens)],
         basis=basis,
@@ -137,6 +155,7 @@ WATER_MOLECULE = ChemistryApplicationInstance(
 
 
 def get_cyclic_ozone_geometry() -> List[Tuple[str, Tuple[float, float, float]]]:
+    """Get the geometry of a cyclic ozone molecule."""
     bond_len = 1.465  # Angstroms
     bond_angle = np.deg2rad(59.9)
 

--- a/src/benchq/problem_ingestion/molecule_instance_generation.py
+++ b/src/benchq/problem_ingestion/molecule_instance_generation.py
@@ -9,8 +9,8 @@ from openfermion.resource_estimates.molecule import (
     localize,
     stability,
 )
-from openfermionpyscf import run_pyscf
-from pyscf import gto, scf
+from openfermionpyscf import run_pyscf, PyscfMolecularData
+from pyscf import scf
 from typing import List, Tuple, Optional
 
 from dataclasses import dataclass
@@ -24,12 +24,12 @@ class ChemistryApplicationInstance:
     basis: str
     multiplicity: int
     charge: int
-    avas_atomic_orbital_list: Optional[List[str]] = None
+    avas_atomic_orbitals: Optional[List[str]] = None
     avas_minao: Optional[str] = None
-    n_active_electrons: Optional[int] = None
-    n_active_orbitals: Optional[int] = None
+    occupied_indices: Optional[List[int]] = None
+    active_indices: Optional[List[int]] = None
 
-    def get_molecular_data(self) -> MolecularData:
+    def get_molecular_data(self) -> PyscfMolecularData:
         """Generates a molecular data object from the instance data."""
         return run_pyscf(
             MolecularData(
@@ -43,23 +43,21 @@ class ChemistryApplicationInstance:
     def get_molecular_hamiltonian(self) -> openfermion.InteractionOperator:
         """Generates an interaction operator from the instance data."""
         return self.get_molecular_data().get_molecular_hamiltonian(
-            n_active_electrons=self.n_active_electrons,
-            n_active_orbitals=self.n_active_orbitals,
+            occupied_indices=self.occupied_indices,
+            active_indices=self.active_indices,
         )
 
     def get_avas_meanfield_object(self) -> scf.hf.SCF:
         """Generates a meanfield object from the instance data."""
         return generate_mean_field_object_from_molecule(
             self.generate_molecular_data(),
-            self.avas_atomic_orbital_list,
+            self.avas_atomic_orbitals,
             self.avas_minao,
         )
 
 
 def generate_mean_field_object_from_molecule(molecule, ao_list, minao="ccpvtz"):
     ### TODO: Consider passing the HF method as an argument in the function
-    # mean_field_object = scf.UHF(molecule)
-    # mean_field_object = scf.ROHF(molecule)
     mean_field_object = scf.ROHF(molecule)
     mean_field_object.verbose = 4
     mean_field_object.kernel()  # run the SCF
@@ -90,7 +88,7 @@ def generate_hydrogen_chain_instance(
         basis=basis,
         charge=0,
         multiplicity=number_of_hydrogens + 1,
-        avas_atomic_orbital_list=[
+        avas_atomic_orbitals=[
             "H 1s",
             "H 2s",
         ]
@@ -99,150 +97,49 @@ def generate_hydrogen_chain_instance(
     )
 
 
-def generate_h2o_mean_field_object():
+WATER_MOLECULE = ChemistryApplicationInstance(
+    geometry=[
+        ("O", (0.000000, -0.075791844, 0.000000)),
+        ("H", (0.866811829, 0.601435779, 0.000000)),
+        ("H", (-0.866811829, 0.601435779, 0.000000)),
+    ],
+    basis="augccpvtz",
+    charge=0,
+    multiplicity=1,
+    avas_atomic_orbitals=["H 1s", "O 2s", "O 2p", "O 3s", "O 3p"],
+)
 
-    molecule = gto.M(
-        atom="""O    0.000000      -0.075791844    0.000000
-                H    0.866811829    0.601435779    0.000000
-                H   -0.866811829    0.601435779    0.000000
-            """,
-        basis="augccpvtz",
-        symmetry=False,
-        charge=1,
-        spin=1,
-    )
-
-    ao_list = ["H 1s", "O 2s", "O 2p", "O 3s", "O 3p"]
-
-    return generate_mean_field_object_from_molecule(molecule, ao_list)
-
-
-def generate_cyclic_ozone_hamiltonian():
-    # Compute geometry of cyclic ozone
+def get_cyclic_ozone_geometry() -> List[Tuple[str, Tuple[float, float, float]]]:
     bond_len = 1.465  # Angstroms
     bond_angle = np.deg2rad(59.9)
 
     x = bond_len * np.sin(bond_angle / 2)
     y = bond_len * np.cos(bond_angle / 2)
 
-    geometry = [("O", (x, -y / 2, 0)), ("O", (-x, -y / 2, 0)), ("O", (0, y / 2, 0))]
+    return [("O", (x, -y / 2, 0)), ("O", (-x, -y / 2, 0)), ("O", (0, y / 2, 0))]
 
-    basis = "cc-pvtz"
-    multiplicity = 3  # Cyclic ozone triplet ground state
-    charge = 0  # Cyclic ozone is a neutral molecule
-
-    # Generate and populate instance of MolecularData for cyclic ozone
-    o3_molecule = openfermion.MolecularData(
-        geometry,
-        basis,
-        multiplicity,
-        charge,
-        description="Cyclic Ozone",
-        symmetry=False,
-    )
-    o3_molecule = run_pyscf(
-        o3_molecule, run_fci=False, run_ccsd=False, run_cisd=False, run_mp2=False
-    )
-
-    # Get molecular Hamiltonian in an active space of
-    # 24 spin orbitals = 12 spatial orbitals
-    active_space_start = 3
-    active_space_stop = 15
-
-    o3_molecular_hamiltonian = o3_molecule.get_molecular_hamiltonian(
-        occupied_indices=range(active_space_start),
-        active_indices=range(active_space_start, active_space_stop),
-    )
-    return o3_molecular_hamiltonian
-
-
-def generate_cyclic_ozone_mean_field_object():
-    # Compute geometry of cyclic ozone
-    bond_len = 1.465  # Angstroms
-    bond_angle = np.deg2rad(59.9)
-
-    x = bond_len * np.sin(bond_angle / 2)
-    y = bond_len * np.cos(bond_angle / 2)
-
-    geometry = [("O", (x, -y / 2, 0)), ("O", (-x, -y / 2, 0)), ("O", (0, y / 2, 0))]
-
-    basis = "sto-3g"
-    # basis = "6-31g"
-    # basis = "cc-pvtz"
-    # basis = "cc-pvdz"
-    multiplicity = 3  # Cyclic ozone triplet ground state
-    # charge = 0  # Cyclic ozone is a neutral molecule
-
-    o3_molecule = gto.M(
-        atom=geometry,
-        basis=basis,
-        symmetry=False,
+CYCLIC_OZONE_MOLECULE = ChemistryApplicationInstance(
+        geometry=get_cyclic_ozone_geometry(),
+        basis="cc-pvtz",
+        multiplicity=3,
         charge=0,
-        spin=multiplicity - 1,
+        avas_atomic_orbitals=[
+            "O 1s",
+            "O 2s",
+            "O 2p",
+            "O 3s",
+            "O 3p",
+            "O 1s",
+            "O 2s",
+            "O 2p",
+            "O 3s",
+            "O 3p",
+            "O 1s",
+            "O 2s",
+            "O 2p",
+            "O 3s",
+            "O 3p",
+        ],
+        occupied_indices=range(3),
+        active_indices=range(3, 15),
     )
-
-    # ao_list = ["O 2s", "O 2p", "O 3s", "O 3p"]
-    ao_list = [
-        "O 1s",
-        "O 2s",
-        "O 2p",
-        "O 3s",
-        "O 3p",
-        "O 1s",
-        "O 2s",
-        "O 2p",
-        "O 3s",
-        "O 3p",
-        "O 1s",
-        "O 2s",
-        "O 2p",
-        "O 3s",
-        "O 3p",
-    ]
-    # ao_list = [
-    #     "O 2s",
-    #     "O 2p",
-    #     "O 2s",
-    #     "O 2p",
-    #     "O 2s",
-    #     "O 2p",
-    # ]
-    # ao_list = [
-    #     "O 2s",
-    #     "O 2p",
-    # ]
-    # ao_list = [
-    #     "O 1s",
-    #     "O 2s",
-    #     "O 2p",
-    #     "O 1s",
-    #     "O 2s",
-    #     "O 2p",
-    #     "O 1s",
-    #     "O 2s",
-    #     "O 2p",
-    # ]
-    # ao_list = []
-
-    # # Generate and populate instance of MolecularData for cyclic ozone
-    # o3_molecule = openfermion.MolecularData(
-    #     geometry, basis, multiplicity, charge, description="Cyclic Ozone"
-    # )
-    # o3_molecule = run_pyscf(
-    #     o3_molecule, run_fci=False, run_ccsd=False, run_cisd=False, run_mp2=False
-    # )
-    return generate_mean_field_object_from_molecule(o3_molecule, ao_list)
-
-
-def generate_c60_geometry():
-
-    # A short script for constructing molecular geometries for OpenFermion
-    # from .xyz files using PySCF
-    mol = gto.M(atom="C60-Ih.xyz")
-    c60_coords = mol.atom_coords(unit="ANG")
-
-    geometry = []
-    for [x, y, z] in c60_coords:
-        geometry.append(("C", (x, y, z)))
-    print(geometry)
-    return geometry

--- a/src/benchq/problem_ingestion/molecule_instance_generation.py
+++ b/src/benchq/problem_ingestion/molecule_instance_generation.py
@@ -18,7 +18,26 @@ from pyscf import scf
 
 @dataclass
 class ChemistryApplicationInstance:
-    """Class for representing chemistry application instances."""
+    """Class for representing chemistry application instances.
+
+    A chemistry application instance is a specification of how to generate a fermionic
+    Hamiltonian, including information such as the molecular geometry and choice of
+    active space. Note that the active space can be specified either through the use of
+    Atomic Valence Active Space (AVAS) or by specifying the indices of the occupied and
+    active orbitals.
+
+    Attributes:
+        geometry: A list of tuples of the form (atom, (x, y, z)) where atom is the
+            atom type and (x, y, z) are the coordinates of the atom.
+        basis: The basis set to use for the calculation.
+        multiplicity: The spin multiplicity of the molecule.
+        charge: The charge of the molecule.
+        avas_atomic_orbitals: A list of atomic orbitals to use for  (AVAS).
+        avas_minao: The minimum active orbital to use for AVAS.
+        occupied_indices: A list of molecular orbitals not in the active space that
+            should be assumed to be fully occupied.
+        active_indices: A list of molecular orbitals to include in the active space.
+    """
 
     geometry: List[Tuple[str, Tuple[float, float, float]]]
     basis: str

--- a/src/benchq/problem_ingestion/molecule_instance_generation.py
+++ b/src/benchq/problem_ingestion/molecule_instance_generation.py
@@ -49,16 +49,15 @@ class ChemistryApplicationInstance:
 
     def get_avas_meanfield_object(self) -> scf.hf.SCF:
         """Generates a meanfield object from the instance data."""
-        return generate_mean_field_object_from_molecule(
-            self.generate_molecular_data(),
+        return truncate_with_avas(
+            self.get_molecular_data()._pyscf_data["scf"],
             self.avas_atomic_orbitals,
             self.avas_minao,
         )
 
 
-def generate_mean_field_object_from_molecule(molecule, ao_list, minao="ccpvtz"):
+def truncate_with_avas(mean_field_object: scf.hf.SCF, ao_list: List[str], minao: str="ccpvtz"):
     ### TODO: Consider passing the HF method as an argument in the function
-    mean_field_object = scf.ROHF(molecule)
     mean_field_object.verbose = 4
     mean_field_object.kernel()  # run the SCF
 

--- a/src/benchq/problem_ingestion/molecule_instance_generation.py
+++ b/src/benchq/problem_ingestion/molecule_instance_generation.py
@@ -1,6 +1,9 @@
 ################################################################################
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Tuple
+
 import numpy as np
 import openfermion
 from openfermion import MolecularData
@@ -9,11 +12,8 @@ from openfermion.resource_estimates.molecule import (
     localize,
     stability,
 )
-from openfermionpyscf import run_pyscf, PyscfMolecularData
+from openfermionpyscf import PyscfMolecularData, run_pyscf
 from pyscf import scf
-from typing import List, Tuple, Optional
-
-from dataclasses import dataclass
 
 
 @dataclass
@@ -24,10 +24,10 @@ class ChemistryApplicationInstance:
     basis: str
     multiplicity: int
     charge: int
-    avas_atomic_orbitals: Optional[List[str]] = None
+    avas_atomic_orbitals: Optional[Iterable[str]] = None
     avas_minao: Optional[str] = None
-    occupied_indices: Optional[List[int]] = None
-    active_indices: Optional[List[int]] = None
+    occupied_indices: Optional[Iterable[int]] = None
+    active_indices: Optional[Iterable[int]] = None
 
     def get_molecular_data(self) -> PyscfMolecularData:
         """Generates a molecular data object from the instance data."""
@@ -56,7 +56,11 @@ class ChemistryApplicationInstance:
         )
 
 
-def truncate_with_avas(mean_field_object: scf.hf.SCF, ao_list: List[str], minao: str="ccpvtz"):
+def truncate_with_avas(
+    mean_field_object: scf.hf.SCF,
+    ao_list: Optional[Iterable[str]] = None,
+    minao: Optional[str] = None,
+):
     ### TODO: Consider passing the HF method as an argument in the function
     mean_field_object.verbose = 4
     mean_field_object.kernel()  # run the SCF
@@ -108,6 +112,7 @@ WATER_MOLECULE = ChemistryApplicationInstance(
     avas_atomic_orbitals=["H 1s", "O 2s", "O 2p", "O 3s", "O 3p"],
 )
 
+
 def get_cyclic_ozone_geometry() -> List[Tuple[str, Tuple[float, float, float]]]:
     bond_len = 1.465  # Angstroms
     bond_angle = np.deg2rad(59.9)
@@ -117,28 +122,29 @@ def get_cyclic_ozone_geometry() -> List[Tuple[str, Tuple[float, float, float]]]:
 
     return [("O", (x, -y / 2, 0)), ("O", (-x, -y / 2, 0)), ("O", (0, y / 2, 0))]
 
+
 CYCLIC_OZONE_MOLECULE = ChemistryApplicationInstance(
-        geometry=get_cyclic_ozone_geometry(),
-        basis="cc-pvtz",
-        multiplicity=3,
-        charge=0,
-        avas_atomic_orbitals=[
-            "O 1s",
-            "O 2s",
-            "O 2p",
-            "O 3s",
-            "O 3p",
-            "O 1s",
-            "O 2s",
-            "O 2p",
-            "O 3s",
-            "O 3p",
-            "O 1s",
-            "O 2s",
-            "O 2p",
-            "O 3s",
-            "O 3p",
-        ],
-        occupied_indices=range(3),
-        active_indices=range(3, 15),
-    )
+    geometry=get_cyclic_ozone_geometry(),
+    basis="cc-pvtz",
+    multiplicity=3,
+    charge=0,
+    avas_atomic_orbitals=[
+        "O 1s",
+        "O 2s",
+        "O 2p",
+        "O 3s",
+        "O 3p",
+        "O 1s",
+        "O 2s",
+        "O 2p",
+        "O 3s",
+        "O 3p",
+        "O 1s",
+        "O 2s",
+        "O 2p",
+        "O 3s",
+        "O 3p",
+    ],
+    occupied_indices=range(3),
+    active_indices=range(3, 15),
+)

--- a/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
+++ b/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
@@ -1,6 +1,7 @@
 import pytest
 
 from benchq.problem_ingestion import (
+    WATER_MOLECULE,
     ChemistryApplicationInstance,
     generate_hydrogen_chain_instance,
 )
@@ -16,20 +17,19 @@ from benchq.problem_ingestion import (
 def test_hamiltonian_has_correct_number_of_qubits(
     instance: ChemistryApplicationInstance, expected_number_of_qubits: int
 ):
-    hamiltonian = instance.get_molecular_hamiltonian()
+    hamiltonian = instance.get_active_space_hamiltonian()
     assert hamiltonian.n_qubits == expected_number_of_qubits
 
 
 @pytest.mark.parametrize(
     "instance,max_number_of_orbitals",
     [
-        (generate_hydrogen_chain_instance(1), 2 * 1),
-        (generate_hydrogen_chain_instance(2), 2 * 2),
+        (WATER_MOLECULE, 2 * 2 + 1 + 3 * 2),
     ],
 )
-def test_avas_mean_field_object_has_valid_number_of_orbitals(
+def test_active_space_mean_field_object_has_valid_number_of_orbitals(
     instance: ChemistryApplicationInstance, max_number_of_orbitals: int
 ):
-    mean_field_object = instance.get_avas_meanfield_object()
+    mean_field_object = instance.get_active_space_meanfield_object()
     assert mean_field_object.mo_coeff.shape[0] <= max_number_of_orbitals
     assert mean_field_object.mo_coeff.shape[1] <= max_number_of_orbitals

--- a/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
+++ b/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
@@ -1,0 +1,34 @@
+from benchq.problem_ingestion import (
+    generate_hydrogen_chain_instance,
+    ChemistryApplicationInstance,
+)
+import pytest
+
+
+@pytest.mark.parametrize(
+    "instance,expected_number_of_qubits",
+    [
+        (generate_hydrogen_chain_instance(1), 2 * 2 * 1),
+        (generate_hydrogen_chain_instance(2), 2 * 2 * 2),
+    ],
+)
+def test_hamiltonian_has_correct_number_of_qubits(
+    instance: ChemistryApplicationInstance, expected_number_of_qubits: int
+):
+    hamiltonian = instance.get_molecular_hamiltonian()
+    assert hamiltonian.n_qubits == expected_number_of_qubits
+
+
+@pytest.mark.parametrize(
+    "instance,max_number_of_orbitals",
+    [
+        (generate_hydrogen_chain_instance(1), 2 * 1),
+        (generate_hydrogen_chain_instance(2), 2 * 2),
+    ],
+)
+def test_avas_mean_field_object_has_valid_number_of_orbitals(
+    instance: ChemistryApplicationInstance, max_number_of_orbitals: int
+):
+    mean_field_object = instance.get_avas_meanfield_object()
+    assert mean_field_object.mo_coeff.shape[0] <= max_number_of_orbitals
+    assert mean_field_object.mo_coeff.shape[1] <= max_number_of_orbitals

--- a/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
+++ b/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
@@ -1,8 +1,9 @@
-from benchq.problem_ingestion import (
-    generate_hydrogen_chain_instance,
-    ChemistryApplicationInstance,
-)
 import pytest
+
+from benchq.problem_ingestion import (
+    ChemistryApplicationInstance,
+    generate_hydrogen_chain_instance,
+)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

The chemistry application instances had some code duplication and inconsistent patterns. This PR addresses this by introducing a `ChemistryApplicationInstance` dataclass based on discussion with @aakunitsa and @mkodrycka. The dataclass encapsulates the information that defines an application instance, such as geometry, charge, and active space.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
