### PR TITLE
test: Add tests for graph compilation resource estimation

### DIFF
--- a/src/benchq/resource_estimation/graph_compilation.py
+++ b/src/benchq/resource_estimation/graph_compilation.py
@@ -8,7 +8,6 @@ from typing import Any, List
 
 import more_itertools
 import networkx as nx
-import numpy as np
 from graph_state_generation.optimizers import greedy_stabilizer_measurement_scheduler
 from graph_state_generation.substrate_scheduler import TwoRowSubstrateScheduler
 from orquestra.quantum.circuits import Circuit

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -60,14 +60,12 @@ def test_get_resource_estimations_for_program_gives_correct_results(
         physical_gate_time_in_seconds=1e-6,
     )
     error_budget = 1e-3
-    print(quantum_program.subroutines[0])
     gsc_resource_estimates = get_resource_estimations_for_program(
         quantum_program,
         error_budget,
         architecture_model,
         plot=True,
     )
-    print(gsc_resource_estimates)
     for key in expected_results.keys():
         assert gsc_resource_estimates[key] == expected_results[key]
 

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -24,7 +24,7 @@ def test_get_resource_estimations_for_program_gives_correct_n_measurement_steps(
         architecture_model,
         plot=True,
     )
-    
+
     assert gsc_resource_estimates["n_measurement_steps"] == 3
     assert gsc_resource_estimates["n_nodes"] == 3
     assert gsc_resource_estimates["max_graph_degree"] == 2
@@ -33,3 +33,64 @@ def test_get_resource_estimations_for_program_gives_correct_n_measurement_steps(
     # logical error. Therefore the expression below is a loose upper bound for the
     # logical error rate.
     assert gsc_resource_estimates["logical_error_rate"] < error_budget
+
+
+def test_better_architecture_does_not_require_more_resources():
+    low_noise_architecture_model = BasicArchitectureModel(
+        physical_gate_error_rate=1e-4,
+        physical_gate_time_in_seconds=1e-6,
+    )
+    high_noise_architecture_model = BasicArchitectureModel(
+        physical_gate_error_rate=1e-3,
+        physical_gate_time_in_seconds=1e-6,
+    )
+    error_budget = 1e-3
+    circuit = Circuit([H(0), RZ(np.pi / 4)(0), CNOT(0, 1)])
+    quantum_program = QuantumProgram(
+        subroutines=[circuit], steps=1, calculate_subroutine_sequence=lambda x: [0]
+    )
+    low_noise_resource_estimates = get_resource_estimations_for_program(
+        quantum_program,
+        error_budget,
+        low_noise_architecture_model,
+        plot=True,
+    )
+    high_noise_resource_estimates = get_resource_estimations_for_program(
+        quantum_program,
+        error_budget,
+        high_noise_architecture_model,
+        plot=True,
+    )
+
+    assert low_noise_resource_estimates["physical_qubit_count"] <= high_noise_resource_estimates["physical_qubit_count"]
+    assert low_noise_resource_estimates["min_viable_distance"] <= high_noise_resource_estimates["min_viable_distance"]
+    assert low_noise_resource_estimates["total_time"] <= high_noise_resource_estimates["total_time"]
+
+
+def test_higher_error_budget_does_not_require_more_resources():
+    architecture_model = BasicArchitectureModel(
+        physical_gate_error_rate=1e-3,
+        physical_gate_time_in_seconds=1e-6,
+    )
+    low_error_budget = 1e-3
+    high_error_budget = 1e-2
+    circuit = Circuit([H(0), RZ(np.pi / 4)(0), CNOT(0, 1)])
+    quantum_program = QuantumProgram(
+        subroutines=[circuit], steps=1, calculate_subroutine_sequence=lambda x: [0]
+    )
+    low_error_resource_estimates = get_resource_estimations_for_program(
+        quantum_program,
+        low_error_budget,
+        architecture_model,
+        plot=True,
+    )
+    high_error_resource_estimates = get_resource_estimations_for_program(
+        quantum_program,
+        high_error_budget,
+        architecture_model,
+        plot=True,
+    )
+
+    assert high_error_resource_estimates["physical_qubit_count"] <= low_error_resource_estimates["physical_qubit_count"]
+    assert high_error_resource_estimates["min_viable_distance"] <= low_error_resource_estimates["min_viable_distance"]
+    assert high_error_resource_estimates["total_time"] <= low_error_resource_estimates["total_time"]

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -1,5 +1,6 @@
 import numpy as np
-from orquestra.quantum.circuits import CNOT, RZ, Circuit, H
+import pytest
+from orquestra.quantum.circuits import CNOT, RX, RY, RZ, Circuit, H, T
 
 from benchq.data_structures.hardware_architecture_models import BasicArchitectureModel
 from benchq.data_structures.quantum_program import QuantumProgram
@@ -8,26 +9,67 @@ from benchq.resource_estimation.graph_compilation import (
 )
 
 
-def test_get_resource_estimations_for_program_gives_correct_n_measurement_steps():
+@pytest.mark.parametrize(
+    "quantum_program,expected_results",
+    [
+        (
+            QuantumProgram(
+                [Circuit([H(0), RZ(np.pi / 4)(0), CNOT(0, 1)])], 1, lambda x: [0]
+            ),
+            {"n_measurement_steps": 3, "n_nodes": 3, "max_graph_degree": 2},
+        ),
+        (
+            QuantumProgram(
+                [Circuit([RX(np.pi / 4)(0), RY(np.pi / 4)(0), CNOT(0, 1)])],
+                1,
+                lambda _: [0],
+            ),
+            {"n_measurement_steps": 3, "n_nodes": 4, "max_graph_degree": 2},
+        ),
+        (
+            QuantumProgram(
+                [Circuit([H(0)] + [CNOT(i, i + 1) for i in range(3)])],
+                1,
+                lambda _: [0],
+            ),
+            {"n_measurement_steps": 4, "n_nodes": 4, "max_graph_degree": 3},
+        ),
+        (
+            QuantumProgram(
+                [Circuit([H(0)] + [CNOT(i, i + 1) for i in range(3)] + [T(1), T(2)])],
+                1,
+                lambda _: [0],
+            ),
+            {"n_measurement_steps": 6, "n_nodes": 6, "max_graph_degree": 5},
+        ),
+        (
+            QuantumProgram(
+                [Circuit([H(0), T(0), CNOT(0, 1), T(2), CNOT(2, 3)])],
+                1,
+                lambda _: [0],
+            ),
+            {"n_measurement_steps": 3, "n_nodes": 6, "max_graph_degree": 2},
+        ),
+    ],
+)
+def test_get_resource_estimations_for_program_gives_correct_results(
+    quantum_program, expected_results
+):
     architecture_model = BasicArchitectureModel(
         physical_gate_error_rate=1e-3,
         physical_gate_time_in_seconds=1e-6,
     )
     error_budget = 1e-3
-    circuit = Circuit([H(0), RZ(np.pi / 4)(0), CNOT(0, 1)])
-    quantum_program = QuantumProgram(
-        subroutines=[circuit], steps=1, calculate_subroutine_sequence=lambda x: [0]
-    )
+    print(quantum_program.subroutines[0])
     gsc_resource_estimates = get_resource_estimations_for_program(
         quantum_program,
         error_budget,
         architecture_model,
         plot=True,
     )
-
-    assert gsc_resource_estimates["n_measurement_steps"] == 3
-    assert gsc_resource_estimates["n_nodes"] == 3
-    assert gsc_resource_estimates["max_graph_degree"] == 2
+    print(gsc_resource_estimates)
+    for key in expected_results.keys():
+        assert gsc_resource_estimates[key] == expected_results[key]
 
     # Note that error_budget is a bound for the sum of the gate synthesis error and
     # logical error. Therefore the expression below is a loose upper bound for the
@@ -62,9 +104,18 @@ def test_better_architecture_does_not_require_more_resources():
         plot=True,
     )
 
-    assert low_noise_resource_estimates["physical_qubit_count"] <= high_noise_resource_estimates["physical_qubit_count"]
-    assert low_noise_resource_estimates["min_viable_distance"] <= high_noise_resource_estimates["min_viable_distance"]
-    assert low_noise_resource_estimates["total_time"] <= high_noise_resource_estimates["total_time"]
+    assert (
+        low_noise_resource_estimates["physical_qubit_count"]
+        <= high_noise_resource_estimates["physical_qubit_count"]
+    )
+    assert (
+        low_noise_resource_estimates["min_viable_distance"]
+        <= high_noise_resource_estimates["min_viable_distance"]
+    )
+    assert (
+        low_noise_resource_estimates["total_time"]
+        <= high_noise_resource_estimates["total_time"]
+    )
 
 
 def test_higher_error_budget_does_not_require_more_resources():
@@ -91,6 +142,15 @@ def test_higher_error_budget_does_not_require_more_resources():
         plot=True,
     )
 
-    assert high_error_resource_estimates["physical_qubit_count"] <= low_error_resource_estimates["physical_qubit_count"]
-    assert high_error_resource_estimates["min_viable_distance"] <= low_error_resource_estimates["min_viable_distance"]
-    assert high_error_resource_estimates["total_time"] <= low_error_resource_estimates["total_time"]
+    assert (
+        high_error_resource_estimates["physical_qubit_count"]
+        <= low_error_resource_estimates["physical_qubit_count"]
+    )
+    assert (
+        high_error_resource_estimates["min_viable_distance"]
+        <= low_error_resource_estimates["min_viable_distance"]
+    )
+    assert (
+        high_error_resource_estimates["total_time"]
+        <= low_error_resource_estimates["total_time"]
+    )

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -1,0 +1,27 @@
+import numpy as np
+from orquestra.quantum.circuits import CNOT, RZ, Circuit, H
+
+from benchq.data_structures.hardware_architecture_models import BasicArchitectureModel
+from benchq.data_structures.quantum_program import QuantumProgram
+from benchq.resource_estimation.graph_compilation import (
+    get_resource_estimations_for_program,
+)
+
+
+def test_get_resource_estimations_for_program_gives_correct_n_measurement_steps():
+    architecture_model = BasicArchitectureModel(
+        physical_gate_error_rate=1e-3,
+        physical_gate_time_in_seconds=1e-6,
+    )
+    error_budget = 1e-3
+    circuit = Circuit([H(0), RZ(np.pi/4)(0), CNOT(0, 1)])
+    quantum_program = QuantumProgram(
+        subroutines=[circuit], steps=1, calculate_subroutine_sequence=lambda x: [0]
+    )
+    gsc_resource_estimates = get_resource_estimations_for_program(
+        quantum_program,
+        error_budget,
+        architecture_model,
+        plot=True,
+    )
+    assert gsc_resource_estimates["n_measurement_steps"] == 3

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -14,7 +14,7 @@ def test_get_resource_estimations_for_program_gives_correct_n_measurement_steps(
         physical_gate_time_in_seconds=1e-6,
     )
     error_budget = 1e-3
-    circuit = Circuit([H(0), RZ(np.pi/4)(0), CNOT(0, 1)])
+    circuit = Circuit([H(0), RZ(np.pi / 4)(0), CNOT(0, 1)])
     quantum_program = QuantumProgram(
         subroutines=[circuit], steps=1, calculate_subroutine_sequence=lambda x: [0]
     )
@@ -24,4 +24,12 @@ def test_get_resource_estimations_for_program_gives_correct_n_measurement_steps(
         architecture_model,
         plot=True,
     )
+    
     assert gsc_resource_estimates["n_measurement_steps"] == 3
+    assert gsc_resource_estimates["n_nodes"] == 3
+    assert gsc_resource_estimates["max_graph_degree"] == 2
+
+    # Note that error_budget is a bound for the sum of the gate synthesis error and
+    # logical error. Therefore the expression below is a loose upper bound for the
+    # logical error rate.
+    assert gsc_resource_estimates["logical_error_rate"] < error_budget


### PR DESCRIPTION
## Description

This PR adds some tests that verify that the resource estimations for graph state compilation are correct for some simple cases.

It would be good if the reviewer could take a look at the expected `n_measurement_steps` for `test_get_resource_estimations_for_program_gives_correct_results` and make sure they make sense.

Also @mstechly note that instead of making a test with RZ at some angle besides pi/4, I added instead a test that combines RX and RY. The reason is that I don't know of any rotation angle for which we can get an exact Clifford + T decomposition of RZ (besides the trivial ones that require zero or one T gates).

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
