### PR TITLE
Changing hydrogen chain multiplicity and openfermion dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     # Temporary using this version as it gives huge performance boost
     pyLIQTR @ git+https://github.com/isi-usc-edu/pyLIQTR@fa74a62a5ecca6ed97822e877574735b5e4cf93b
     # Temporary using this version to get around the limit of length of h chains
-    openfermion @ git+https://github.com/zapatacomputing/OpenFermion@5b4aa97eb568baee576b04553ddf3055216eca3e
+    openfermion
     graph-state-generation @ git+https://github.com/sfc-aqua/gosc-graph-state-generation
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     # Temporary using this version as it gives huge performance boost
     pyLIQTR @ git+https://github.com/isi-usc-edu/pyLIQTR@fa74a62a5ecca6ed97822e877574735b5e4cf93b
     # Temporary using this version to get around the limit of length of h chains
-    openfermion
+    openfermion==1.5.1
     graph-state-generation @ git+https://github.com/sfc-aqua/gosc-graph-state-generation
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     # Temporary using this version as it gives huge performance boost
     pyLIQTR @ git+https://github.com/isi-usc-edu/pyLIQTR@fa74a62a5ecca6ed97822e877574735b5e4cf93b
     # Temporary using this version to get around the limit of length of h chains
-    openfermion==1.5.1
+    openfermion~=1.5.0
     graph-state-generation @ git+https://github.com/sfc-aqua/gosc-graph-state-generation
 
 [options.packages.find]

--- a/src/benchq/problem_ingestion/molecule_instance_generation.py
+++ b/src/benchq/problem_ingestion/molecule_instance_generation.py
@@ -136,7 +136,7 @@ def generate_hydrogen_chain_instance(
         geometry=[("H", (0, 0, i * bond_distance)) for i in range(number_of_hydrogens)],
         basis=basis,
         charge=0,
-        multiplicity=number_of_hydrogens + 1,
+        multiplicity=number_of_hydrogens % 2 + 1,
     )
 
 

--- a/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
+++ b/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
@@ -11,6 +11,7 @@ from benchq.problem_ingestion import (
     [
         (generate_hydrogen_chain_instance(1), 2 * 2 * 1),
         (generate_hydrogen_chain_instance(2), 2 * 2 * 2),
+        (generate_hydrogen_chain_instance(13, basis="STO-3G"), 2 * 1 * 13),
     ],
 )
 def test_hamiltonian_has_correct_number_of_qubits(


### PR DESCRIPTION
## Description

This PR addresses two issues: first, the hydrogen chain problem instance currently sets the spin multiplicity to a value that does not correspond to the ground state. Second, the high spin multiplicities required by long hydrogen chains require a modified version of openfermion to be used.

To address this, this PR changes the spin multiplicity of the hydrogen chain application instance to be 1 for even numbers of hydrogen atoms and 2 for odd numbers of hydrogen atoms. (See [Motta et al.](https://journals.aps.org/prx/pdf/10.1103/PhysRevX.10.031058) for details on the ground state of the hydrogen chain.) The dependencies are also updated to remove the commit pin for openfermion. 

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
