### PR TITLE
Make PySCF optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,20 @@ Graph compilation requires non-Python dependencies to be installed.
 2. Make sure `julia` executable is on your `$PATH`. You can test it by running `julia` in a new terminal window.
 3. Install Julia dependencies: open `julia` REPL, press `]`, run `add JSON` and `add Jabalizer`.
 
+If you plan to use PySCF to generate Hamiltonians, use the `pyscf` install extra:
+```bash
+pip install '.[pyscf]'
+```
+
 To run resource estimation for Microsoft, one needs to have Microsoft Resource Estimation package configured. I'm not sure if that's even possible for a general audience at the moment.
 
 ## Usage
 
 Please take a look at the `examples` directory. 
 We have multiple examples there:
-- `h_chain_te.py` shows how to use graph state compilation on a simple hydrogen chain example
-- `h_chain_qasm.py` shows how to use graph state compilation when the circuit is loaded from QASM
-- `qsp_vlasov.py` shows how to perform resource estimation 
+- `h_chain_trotter.py` shows how to use graph state compilation on a simple hydrogen chain example. (Requires `pyscf` install extra.)
+- `h_chain_from_qasm.py` shows how to use graph state compilation when the circuit is loaded from QASM.
+- `qsp_vlasov.py` shows how to perform resource estimation.
 
 
 ## Development and Contribution

--- a/examples/advanced_estimates.py
+++ b/examples/advanced_estimates.py
@@ -6,8 +6,10 @@ import time
 from benchq import BasicArchitectureModel
 from benchq.algorithms import get_qsp_program
 from benchq.problem_ingestion import (
-    generate_hydrogen_chain_instance,
     generate_jw_qubit_hamiltonian_from_mol_data,
+)
+from benchq.problem_ingestion.molecule_instance_generation import (
+    generate_hydrogen_chain_instance,
 )
 from benchq.resource_estimation import get_qpe_resource_estimates_from_mean_field_object
 
@@ -34,9 +36,10 @@ def print_re(resource_estimates, label):
 
 
 def get_of_resource_estimates(n_hydrogens):
-    mean_field_object = generate_hydrogen_chain_instance(
-        n_hydrogens
-    ).get_active_space_meanfield_object()
+    instance = generate_hydrogen_chain_instance(n_hydrogens)
+    instance.avas_atomic_orbitals = ["H 1s", "H 2s"]
+    instance.avas_minao = "STO-3G"
+    mean_field_object = instance.get_active_space_meanfield_object()
 
     # Running resource estimation with OpenFermion tools
 

--- a/examples/h_chain_trotter.py
+++ b/examples/h_chain_trotter.py
@@ -34,7 +34,7 @@ def main():
 
         begtime = time.time()
         start = begtime
-        mol_data = generate_hydrogen_chain_instance(n_hydrogens).get_molecular_data()
+        mol_data = generate_hydrogen_chain_instance(n_hydrogens)
         print("Generate instance:", time.time() - start)
 
         # Convert instance to core computational problem instance

--- a/examples/h_chain_trotter.py
+++ b/examples/h_chain_trotter.py
@@ -18,8 +18,10 @@ import time
 from benchq import BasicArchitectureModel
 from benchq.algorithms import get_trotter_program
 from benchq.problem_ingestion import (
-    generate_hydrogen_chain_instance,
     generate_jw_qubit_hamiltonian_from_mol_data,
+)
+from benchq.problem_ingestion.molecule_instance_generation import (
+    generate_hydrogen_chain_instance,
 )
 from benchq.resource_estimation.graph_compilation import (
     get_resource_estimations_for_program,

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,7 @@ install_requires =
     orquestra-sdk~=0.43.0
     matplotlib>=3.6
     numpy>=1.20
-    portalocker # It's dependency for pyLIQTR 
-    openfermionpyscf==0.5
-    pyscf==2.0.1
+    portalocker # It's dependency for pyLIQTR
     more-itertools
     pandas
     pyLIQTR @ git+https://github.com/isi-usc-edu/pyLIQTR@v0.3.0
@@ -51,3 +49,9 @@ dev =
     orquestra-python-dev
     # Used in tests
     numpy
+    pyscf~=2.2.0
+    openfermionpyscf==0.5
+
+pyscf =
+    pyscf~=2.2.0
+    openfermionpyscf==0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,8 @@ install_requires =
     more-itertools
     pandas
     pyLIQTR @ git+https://github.com/isi-usc-edu/pyLIQTR@v0.3.0
-    # Temporary using this version to get around the limit of length of h chains
     openfermion~=1.5.0
+    pytest # required by OpenFermion's resource_estimates module
     graph-state-generation @ git+https://github.com/sfc-aqua/gosc-graph-state-generation
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,7 @@ dev =
     orquestra-python-dev
     # Used in tests
     numpy
-    pyscf~=2.2.0
-    openfermionpyscf==0.5
+    benchq[pyscf]
 
 pyscf =
     pyscf~=2.2.0

--- a/src/benchq/problem_ingestion/__init__.py
+++ b/src/benchq/problem_ingestion/__init__.py
@@ -5,10 +5,4 @@ from .hamiltonian_generation import (
     generate_fermi_hubbard_jw_qubit_hamiltonian,
     generate_jw_qubit_hamiltonian_from_mol_data,
 )
-from .molecule_instance_generation import (
-    CYCLIC_OZONE_MOLECULE,
-    WATER_MOLECULE,
-    ChemistryApplicationInstance,
-    generate_hydrogen_chain_instance,
-)
 from .vlasov import get_vlasov_hamiltonian

--- a/src/benchq/problem_ingestion/molecule_instance_generation.py
+++ b/src/benchq/problem_ingestion/molecule_instance_generation.py
@@ -78,8 +78,13 @@ class ChemistryApplicationInstance:
         object."""
         if self.active_indices or self.occupied_indices:
             raise ValueError(
-                "Generating the meanfield object for application instances with"
+                "Generating the meanfield object for application instances with "
                 "active and occupied indices is not currently supported."
+            )
+        if not self.avas_atomic_orbitals or not self.avas_minao:
+            raise ValueError(
+                "Generating the meanfield object for application instances without "
+                "avas_atomic_orbitals and avas_minao is not currently supported."
             )
         return truncate_with_avas(
             self.get_molecular_data()._pyscf_data["scf"],

--- a/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
+++ b/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from benchq.problem_ingestion import (
+from benchq.problem_ingestion.molecule_instance_generation import (
     ChemistryApplicationInstance,
     generate_hydrogen_chain_instance,
 )


### PR DESCRIPTION
## Description

A number of users have encountered problems with installing PySCF. Some people don't actually need to use the benchq features that depend on PySCF, so making PySCF optional could be helpful. This PR moves the PySCF dependency into a `pyscf` install extra, and also bumps PySCF to the latest version (2.2.0). It also fixes some bugs that were causing a few of the examples to fail.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
