### PR TITLE
Improve performance of get qsp program

### DIFF
--- a/src/benchq/problem_embeddings/_qsp.py
+++ b/src/benchq/problem_embeddings/_qsp.py
@@ -147,28 +147,29 @@ def _replace_resets(ops: Iterable[cirq.Operation]) -> List[cirq.Operation]:
     ]
 
 
+def _is_identity(gate):
+    return (
+        gate == cirq.I or
+        (
+            isinstance(gate, cirq.XPowGate) and
+            (gate.global_shift==-0.25 or gate.exponent==-1)
+        )
+    )
+
+
 def _replace_gate(op):
     if isinstance(op.gate, cirq.YPowGate):
         if op.gate.exponent == 0.5:
             return cirq.Ry(rads=op.gate.exponent / np.pi).on(op.qubits[0])
         if op.gate.exponent == -0.5:
             return cirq.Ry(rads=-op.gate.exponent / np.pi).on(op.qubits[0])
-    elif op.gate == cirq.XPowGate(global_shift=-0.25):
-        # No need to include identity gates
-        # yield cirq.I.on(op.qubits[0])
-        return None
-    elif op.gate == cirq.XPowGate(exponent=-1):
-        # No need to include identity gates
-        # yield cirq.I.on(op.qubits[0])
+    elif _is_identity(op.gate):
         return None
     elif op.gate == cirq.ZPowGate(exponent=-1):
         # TODO: requires verification!
         return cirq.Z.on(op.qubits[0])
     elif op.gate == cirq.CZPowGate(exponent=-1):
         return cirq.CZ.on(op.qubits[0], op.qubits[1])
-    elif op.gate == cirq.I:
-        # No need to include identity gates
-        return None
     else:
         return op
 

--- a/src/benchq/problem_embeddings/_qsp.py
+++ b/src/benchq/problem_embeddings/_qsp.py
@@ -172,7 +172,7 @@ CZPOW_GATE_CZ_EQUIVALENT = cirq.CZPowGate(exponent=-1)
 
 
 def _replace_gate(op: cirq.Operation) -> Optional[cirq.Operation]:
-    if isinstance(op.gate, cirq.YPowGate) and  op.gate.exponent == 0.5:
+    if isinstance(op.gate, cirq.YPowGate) and op.gate.exponent == 0.5:
         return cirq.Ry(rads=op.gate.exponent / np.pi).on(op.qubits[0])
     elif isinstance(op.gate, cirq.YPowGate) and op.gate.exponent == -0.5:
         return cirq.Ry(rads=-op.gate.exponent / np.pi).on(op.qubits[0])

--- a/src/benchq/problem_embeddings/_qsp.py
+++ b/src/benchq/problem_embeddings/_qsp.py
@@ -140,10 +140,6 @@ def _replace_named_qubit(circuit: cirq.Circuit) -> cirq.Circuit:
     return circuit.transform_qubits(qubit_map )  # type: ignore
 
 
-def _replace_resets(ops: Iterable[cirq.Operation]) -> List[cirq.Operation]:
-    return [op for op in ops if op.gate != cirq.ResetChannel()]
-
-
 XPOW_IDENTITY_1 = cirq.XPowGate(exponent=-1)
 XPOW_IDENTITY_2 = cirq.XPowGate(global_shift=-0.25)
 RESET_CHANNEL = cirq.ResetChannel()

--- a/src/benchq/problem_embeddings/_qsp.py
+++ b/src/benchq/problem_embeddings/_qsp.py
@@ -172,11 +172,10 @@ CZPOW_GATE_CZ_EQUIVALENT = cirq.CZPowGate(exponent=-1)
 
 
 def _replace_gate(op: cirq.Operation) -> Optional[cirq.Operation]:
-    if isinstance(op.gate, cirq.YPowGate):
-        if op.gate.exponent == 0.5:
-            return cirq.Ry(rads=op.gate.exponent / np.pi).on(op.qubits[0])
-        if op.gate.exponent == -0.5:
-            return cirq.Ry(rads=-op.gate.exponent / np.pi).on(op.qubits[0])
+    if isinstance(op.gate, cirq.YPowGate) and  op.gate.exponent == 0.5:
+        return cirq.Ry(rads=op.gate.exponent / np.pi).on(op.qubits[0])
+    elif isinstance(op.gate, cirq.YPowGate) and op.gate.exponent == -0.5:
+        return cirq.Ry(rads=-op.gate.exponent / np.pi).on(op.qubits[0])
     elif _is_identity(cast(cirq.Gate, op.gate)):
         return None
     elif op.gate == ZPOW_GATE_Z_EQUIVALENT:
@@ -184,8 +183,8 @@ def _replace_gate(op: cirq.Operation) -> Optional[cirq.Operation]:
         return cirq.Z.on(op.qubits[0])
     elif op.gate == CZPOW_GATE_CZ_EQUIVALENT:
         return cirq.CZ.on(op.qubits[0], op.qubits[1])
-
-    return op
+    else:
+        return op
 
 
 def _simplify_gates(ops: Iterable[cirq.Operation]) -> List[cirq.Operation]:

--- a/src/benchq/problem_embeddings/_qsp.py
+++ b/src/benchq/problem_embeddings/_qsp.py
@@ -150,10 +150,8 @@ def _replace_resets(ops: Iterable[cirq.Operation]) -> List[cirq.Operation]:
 def _is_identity(gate):
     return (
         gate == cirq.I or
-        (
-            isinstance(gate, cirq.XPowGate) and
-            (gate.global_shift==-0.25 or gate.exponent==-1)
-        )
+        gate == cirq.XPowGate(exponent=-1) or
+        gate == cirq.XPowGate(global_shift=-0.25)
     )
 
 

--- a/tests/benchq/problem_embeddings/test_qsp.py
+++ b/tests/benchq/problem_embeddings/test_qsp.py
@@ -67,13 +67,13 @@ class TestGetQSPCircuit:
 
         # Then
         # We expect this many gates being applied in the circuit
-        assert len(circuit.operations) == 347
+        assert len(circuit.operations) == 349
 
         # We expect the following gate types being applied n times
         assert _gate_op_counts(circuit) == {
             "CZ": 84,
             "RX": 3,
-            "RY": 188,
+            "RY": 190,
             "S": 8,
             "S_Dagger": 8,
             "T": 28,
@@ -96,13 +96,13 @@ class TestGetQSPProgram:
 
         # Then
         # We expect this many gates being applied in the circuit
-        assert len(circuit_from_program.operations) == 347
+        assert len(circuit_from_program.operations) == 349
 
         # We expect the following gate types being applied n times
         assert _gate_op_counts(circuit_from_program) == {
             "CZ": 84,
             "RX": 3,
-            "RY": 188,
+            "RY": 190,
             "S": 8,
             "S_Dagger": 8,
             "T": 28,


### PR DESCRIPTION
## Description

This PR conssiderably improves the performance of `get_qsp_program` function. It does so by:

- avoiding creation of intermediate circuits
- avoding using circuit addition (instead relying on constructing needed operatiosn in advance)
- avoding `cirq.map_operations_and_unroll`

Unfornunately, benchmarks seems to be broken on `main`, but I tested the performance by profiling the following script and examing only the part of the execution tree corresponding to `get_qsp_program`. For this particular example, the introduced changes brought the execution time (when profiling) from ~151s to ~15s

```python
from benchq.algorithms import qsp_time_evolution_algorithm
from benchq.data_structures import ErrorBudget
from benchq.problem_ingestion import (
    generate_jw_qubit_hamiltonian_from_mol_data,
)
from benchq.problem_ingestion.molecule_instance_generation import (
    generate_hydrogen_chain_instance,
)


def main():
    evolution_time = 5

    error_budget = ErrorBudget(ultimate_failure_tolerance=1e-3)

    qsp_time_evolution_algorithm(
        generate_jw_qubit_hamiltonian_from_mol_data(
            generate_hydrogen_chain_instance(3)
        ),
        evolution_time,
        error_budget.circuit_generation_failure_tolerance,
    )


if __name__ == "__main__":
    main()
```

As demonstrated in the profiling pictures attached, it seems that the only way of further improving performance here is to manually reimplement decomposition instead of using `cirq.decompose`, which, if we decided to do so, should be a separate task.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.

*Before*:
![before](https://user-images.githubusercontent.com/5444492/233880714-542e152b-8520-4035-9c1f-0e62efc5102d.png)
*After*:
![after](https://user-images.githubusercontent.com/5444492/233880718-832e3ae6-6e63-463f-a253-ff66614ed789.png)

