### PR TITLE
OpenFermion estimates using ERI

### DIFF
--- a/src/benchq/resource_estimation/__init__.py
+++ b/src/benchq/resource_estimation/__init__.py
@@ -1,4 +1,4 @@
 ################################################################################
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
-from .openfermion_re import get_qpe_resource_estimates_from_mean_field_object
+from .openfermion_re import get_single_factorized_qpe_resource_estimate

--- a/src/benchq/resource_estimation/_compute_lambda_sf.py
+++ b/src/benchq/resource_estimation/_compute_lambda_sf.py
@@ -1,0 +1,45 @@
+#   Copyright 2017 The OpenFermion Developers
+#   Modifications copyright 2023 Zapata Computing, Inc. to allow lambda to be calculated
+#       from molecular integrals.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import numpy as np
+
+
+def compute_lambda(h1, eri_full, sf_factors):
+    """Compute lambda for Hamiltonian using SF method of Berry, et al.
+    Args:
+        pyscf_mf - PySCF mean field object
+        sf_factors (ndarray) - (N x N x rank) array of SF factors from rank
+            reduction of ERI
+    Returns:
+        lambda_tot (float) - lambda value for the single factorized Hamiltonian
+    """
+
+    # Effective one electron operator contribution
+    T = (
+        h1
+        - 0.5 * np.einsum("pqqs->ps", eri_full, optimize=True)
+        + np.einsum("pqrr->pq", eri_full, optimize=True)
+    )
+
+    lambda_T = np.sum(np.abs(T))
+
+    # Two electron operator contributions
+    lambda_W = 0.25 * np.einsum(
+        "ijP,klP->", np.abs(sf_factors), np.abs(sf_factors), optimize=True
+    )
+    lambda_tot = lambda_T + lambda_W
+
+    return lambda_tot

--- a/src/benchq/resource_estimation/openfermion_re.py
+++ b/src/benchq/resource_estimation/openfermion_re.py
@@ -65,8 +65,10 @@ def get_single_factorized_qpe_resource_estimate(
     2, 030305.
 
     Args:
-        h1 (np.ndarray): Matrix elements of the one-body operator that includes kinetic energy operator and electorn-nuclear Coulomb operator.
-        eri (np.ndarray): Four-dimensional array containing electron-repulsion integrals.
+        h1 (np.ndarray): Matrix elements of the one-body operator that includes kinetic
+            energy operator and electorn-nuclear Coulomb operator.
+        eri (np.ndarray): Four-dimensional array containing electron-repulsion
+            integrals.
         rank (int): Rank of the factorization.
         allowable_phase_estimation_error (float): Allowable error in phase estimation.
             Corresponds to epsilon_QPE in the paper.


### PR DESCRIPTION
## Description

Currently, the benchq integration with OpenFermion performs resource estimates on pyscf meanfield objects. However, we have several cases where we'd like to get OpenFermion resource estimates using only the molecular integrals. (For example, the HRL anti-corrosive instances and the L3-Zapata catalysis instances.)

This pull request refactors the OpenFermion integration to accept molecular integrals rather than a pyscf meanfield object.

For users who still wish to get resource estimates for pyscf objects, the one- and two-body integrals can be obtained as follows:
```python
from benchq.resource_estimation import get_single_factorized_qpe_resource_estimate
from openfermion.resource_estimates.molecule import pyscf_to_cas

h1, eri_full, _, _, _ = pyscf_to_cas(mean_field_object)
resource_estimate = get_single_factorized_qpe_resource_estimate(h1, eri_full, rank)
```

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
