### PR TITLE
DTA-2 132/Adjust expected results for commented out test cases

### DIFF
--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -3,7 +3,7 @@ from dataclasses import asdict
 
 import numpy as np
 import pytest
-from orquestra.quantum.circuits import CNOT, RZ, Circuit, H, T
+from orquestra.quantum.circuits import CNOT, RX, RY, RZ, Circuit, H, T
 
 from benchq.data_structures import (
     BasicArchitectureModel,
@@ -90,21 +90,23 @@ def test_get_resource_estimations_for_program_gives_correct_results(
         ultimate_failure_tolerance=1e-2, circuit_generation_weight=0
     )
     transformers = _get_transformers(use_delayed_gate_synthesis, error_budget)
-    gsc_resource_estimates = run_resource_estimation_pipeline(
+    gsc_resource_estimates = asdict(run_resource_estimation_pipeline(
         quantum_program,
         error_budget,
         estimator=GraphResourceEstimator(architecture_model),
         transformers=transformers,
-    )
+    ))
 
-    for key in expected_results.keys():
-        assert asdict(gsc_resource_estimates)[key] == expected_results[key]
+    # Extract only keys that we want to compare
+    assert {
+        key: gsc_resource_estimates[key] for key in expected_results
+    } == expected_results
 
     # Note that error_budget is a bound for the sum of the gate synthesis error and
     # logical error. Therefore the expression below is a loose upper bound for the
     # logical error rate.
     assert (
-        asdict(gsc_resource_estimates)["logical_error_rate"]
+        gsc_resource_estimates["logical_error_rate"]
         < error_budget.ultimate_failure_tolerance
     )
 

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -53,12 +53,12 @@ def _get_transformers(use_delayed_gate_synthesis, error_budget):
             ),
             {"n_measurement_steps": 3, "n_nodes": 3, "n_logical_qubits": 2},
         ),
-        # (
-        #     get_program_from_circuit(
-        #         Circuit([RX(np.pi / 4)(0), RY(np.pi / 4)(0), CNOT(0, 1)])
-        #     ),
-        #     {"n_measurement_steps": 3, "n_nodes": 4, "n_logical_qubits": 2},
-        # ),
+        (
+            get_program_from_circuit(
+                Circuit([RX(np.pi / 4)(0), RY(np.pi / 4)(0), CNOT(0, 1)])
+            ),
+            {"n_measurement_steps": 4, "n_nodes": 4, "n_logical_qubits": 3},
+        ),
         (
             get_program_from_circuit(
                 Circuit([H(0)] + [CNOT(i, i + 1) for i in range(3)])

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -71,12 +71,12 @@ def _get_transformers(use_delayed_gate_synthesis, error_budget):
             ),
             {"n_measurement_steps": 6, "n_nodes": 6, "n_logical_qubits": 5},
         ),
-        # (
-        #     get_program_from_circuit(
-        #         Circuit([H(0), T(0), CNOT(0, 1), T(2), CNOT(2, 3)])
-        #     ),
-        #     {"n_measurement_steps": 3, "n_nodes": 3, "n_logical_qubits": 2},
-        # ),
+        (
+            get_program_from_circuit(
+                Circuit([H(0), T(0), CNOT(0, 1), T(2), CNOT(2, 3)])
+            ),
+            {"n_measurement_steps": 3, "n_nodes": 6, "n_logical_qubits": 2},
+        ),
     ],
 )
 def test_get_resource_estimations_for_program_gives_correct_results(

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -90,12 +90,14 @@ def test_get_resource_estimations_for_program_gives_correct_results(
         ultimate_failure_tolerance=1e-2, circuit_generation_weight=0
     )
     transformers = _get_transformers(use_delayed_gate_synthesis, error_budget)
-    gsc_resource_estimates = asdict(run_resource_estimation_pipeline(
-        quantum_program,
-        error_budget,
-        estimator=GraphResourceEstimator(architecture_model),
-        transformers=transformers,
-    ))
+    gsc_resource_estimates = asdict(
+        run_resource_estimation_pipeline(
+            quantum_program,
+            error_budget,
+            estimator=GraphResourceEstimator(architecture_model),
+            transformers=transformers,
+        )
+    )
 
     # Extract only keys that we want to compare
     assert {


### PR DESCRIPTION
## Description

After refactoring and switching to `graph_sim_mini` two of the resource estimation test cases stopped working and were consequently commented out. After discussing it with @AthenaCaesura we decided that the test cases should be restored with some adjustments to the expected results.

Additionally, this PR improves how the actual results are compared to the expected ones. Instead of comparing the items one by one (which terminates test case after first failure), we compare whole dictionaries, which gives us a detailed information of all failing comparisons at once.

The updates to the expected resource estimates are caused by differences in outputs between `graph_sim_mini` and previously used `Jabalizer`, and are described in detail below.

### First test case

```python
circuit = Circuit([RX(np.pi / 4)(0), RY(np.pi / 4)(0), CNOT(0, 1)])
```

In this case Jabalizer produces grah with lower maximum node degree than `graph_sim_mini`, and hence the refactor caused some estimates to increase.

### Second test case
```python
circuit = Circuit([H(0), T(0), CNOT(0, 1), T(2), CNOT(2, 3)])
```

in this case graph returned by Jabalizer does not contain the isolated nodes, which `graph_sim_mini` includes. This does not increase resource estimates like number of qubits or measurement steps, but increases the overall number of graph nodes which we also test.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
