### PR TITLE
Removing automatic resource estimator from top level package

### DIFF
--- a/src/benchq/__init__.py
+++ b/src/benchq/__init__.py
@@ -12,4 +12,3 @@ from .data_structures.hardware_architecture_models import (
     BASIC_ION_TRAP_ARCHITECTURE_MODEL,
     BASIC_SC_ARCHITECTURE_MODEL,
 )
-from .resource_estimation.graph import automatic_resource_estimator


### PR DESCRIPTION
## Description

Currently, jabalizer must be installed in order to use any part of the benchq Python API. This is because the automatic resource estimator is imported in the top-level package. This pull request addresses this by removing the automatic resource estimator from the top level. 

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
