### PR TITLE
Clean up ResourceInfo class

### DIFF
--- a/src/benchq/data_structures/__init__.py
+++ b/src/benchq/data_structures/__init__.py
@@ -14,7 +14,7 @@ from .hardware_architecture_models import (
     BasicArchitectureModel,
 )
 from .quantum_program import QuantumProgram, get_program_from_circuit
-from .resource_info import ResourceInfo
+from .resource_info import DecoderInfo, ResourceInfo
 
 __all__ = [
     "AlgorithmImplementation",
@@ -28,4 +28,5 @@ __all__ = [
     "QuantumProgram",
     "get_program_from_circuit",
     "ResourceInfo",
+    "DecoderInfo",
 ]

--- a/src/benchq/data_structures/__init__.py
+++ b/src/benchq/data_structures/__init__.py
@@ -14,3 +14,18 @@ from .hardware_architecture_models import (
     BasicArchitectureModel,
 )
 from .quantum_program import QuantumProgram, get_program_from_circuit
+from .resource_info import ResourceInfo
+
+__all__ = [
+    "AlgorithmImplementation",
+    "get_algorithm_description_from_circuit",
+    "DecoderModel",
+    "ErrorBudget",
+    "GraphPartition",
+    "BASIC_ION_TRAP_ARCHITECTURE_MODEL",
+    "BASIC_SC_ARCHITECTURE_MODEL",
+    "BasicArchitectureModel",
+    "QuantumProgram",
+    "get_program_from_circuit",
+    "ResourceInfo",
+]

--- a/src/benchq/data_structures/__init__.py
+++ b/src/benchq/data_structures/__init__.py
@@ -14,7 +14,14 @@ from .hardware_architecture_models import (
     BasicArchitectureModel,
 )
 from .quantum_program import QuantumProgram, get_program_from_circuit
-from .resource_info import DecoderInfo, GraphData, GraphResourceInfo, ResourceInfo
+from .resource_info import (
+    DecoderInfo,
+    ExtrapolatedGraphData,
+    ExtrapolatedGraphResourceInfo,
+    GraphData,
+    GraphResourceInfo,
+    ResourceInfo,
+)
 
 __all__ = [
     "AlgorithmImplementation",
@@ -31,4 +38,6 @@ __all__ = [
     "DecoderInfo",
     "GraphResourceInfo",
     "GraphData",
+    "ExtrapolatedGraphData",
+    "ExtrapolatedGraphResourceInfo",
 ]

--- a/src/benchq/data_structures/__init__.py
+++ b/src/benchq/data_structures/__init__.py
@@ -14,7 +14,12 @@ from .hardware_architecture_models import (
     BasicArchitectureModel,
 )
 from .quantum_program import QuantumProgram, get_program_from_circuit
-from .resource_info import DecoderInfo, ResourceInfo
+from .resource_info import (
+    DecoderInfo,
+    GraphCompilationResourceInfo,
+    GraphData,
+    ResourceInfo,
+)
 
 __all__ = [
     "AlgorithmImplementation",
@@ -29,4 +34,6 @@ __all__ = [
     "get_program_from_circuit",
     "ResourceInfo",
     "DecoderInfo",
+    "GraphCompilationResourceInfo",
+    "GraphData",
 ]

--- a/src/benchq/data_structures/__init__.py
+++ b/src/benchq/data_structures/__init__.py
@@ -14,12 +14,7 @@ from .hardware_architecture_models import (
     BasicArchitectureModel,
 )
 from .quantum_program import QuantumProgram, get_program_from_circuit
-from .resource_info import (
-    DecoderInfo,
-    GraphCompilationResourceInfo,
-    GraphData,
-    ResourceInfo,
-)
+from .resource_info import DecoderInfo, GraphData, GraphResourceInfo, ResourceInfo
 
 __all__ = [
     "AlgorithmImplementation",
@@ -34,6 +29,6 @@ __all__ = [
     "get_program_from_circuit",
     "ResourceInfo",
     "DecoderInfo",
-    "GraphCompilationResourceInfo",
+    "GraphResourceInfo",
     "GraphData",
 ]

--- a/src/benchq/data_structures/__init__.py
+++ b/src/benchq/data_structures/__init__.py
@@ -15,6 +15,8 @@ from .hardware_architecture_models import (
 )
 from .quantum_program import QuantumProgram, get_program_from_circuit
 from .resource_info import (
+    AzureExtra,
+    AzureResourceInfo,
     DecoderInfo,
     ExtrapolatedGraphData,
     ExtrapolatedGraphResourceInfo,
@@ -40,4 +42,6 @@ __all__ = [
     "GraphData",
     "ExtrapolatedGraphData",
     "ExtrapolatedGraphResourceInfo",
+    "AzureResourceInfo",
+    "AzureExtra",
 ]

--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -40,12 +40,12 @@ class GraphData:
     n_measurement_steps: int
 
 
-GraphCompilationResourceInfo = ResourceInfo[GraphData]
+GraphResourceInfo = ResourceInfo[GraphData]
 
 
 @dataclass
 class ExtrapolatedGraphData(GraphData):
     n_logical_qubits_r_squared: float
     n_measurement_steps_r_squared: float
-    data_used_to_extrapolate: List[GraphCompilationResourceInfo]
+    data_used_to_extrapolate: List[GraphResourceInfo]
     steps_to_extrapolate_to: int

--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -47,5 +47,12 @@ GraphResourceInfo = ResourceInfo[GraphData]
 class ExtrapolatedGraphData(GraphData):
     n_logical_qubits_r_squared: float
     n_measurement_steps_r_squared: float
-    data_used_to_extrapolate: List[GraphResourceInfo]
-    steps_to_extrapolate_to: int
+    data_used_to_extrapolate: List[GraphResourceInfo] = field(repr=False)
+    steps_to_extrapolate_to: int = field(repr=False)
+
+    @property
+    def max_graph_degree_r_squared(self) -> float:
+        return self.n_logical_qubits_r_squared
+
+
+ExtrapolatedGraphResourceInfo = ResourceInfo[ExtrapolatedGraphData]

--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -10,6 +10,8 @@ TExtra = TypeVar("TExtra")
 
 @dataclass
 class DecoderInfo:
+    """Information relating the deceoder."""
+
     total_energy_consumption: float
     power: float
     area: float
@@ -18,7 +20,16 @@ class DecoderInfo:
 
 @dataclass
 class ResourceInfo(Generic[TExtra]):
-    """Contains all resource estimated for a problem instance."""
+    """Generic information about estimated resources with possible extras.
+
+    The generic parameter of this class is a type of extra information stored
+    in the extra field. This information should relate to the specific
+    compilation method or algorithm used for estimating resources.
+
+    Other fields are commont between estimation methods that we currently have.
+
+    There are several variants of this class aliased below.
+    """
 
     code_distance: int
     logical_error_rate: float
@@ -31,7 +42,7 @@ class ResourceInfo(Generic[TExtra]):
 
 @dataclass
 class GraphData:
-    """Contains minimal set of data to get a resource estimate for a graph."""
+    """Minimal set of graph-related data needed for resource estimation."""
 
     max_graph_degree: int
     n_nodes: int
@@ -40,11 +51,14 @@ class GraphData:
     n_measurement_steps: int
 
 
+# Alias for type of resource info returned by GraphResourceEstimator
 GraphResourceInfo = ResourceInfo[GraphData]
 
 
 @dataclass
 class ExtrapolatedGraphData(GraphData):
+    """GraphData extended with extrapolation-related info."""
+
     n_logical_qubits_r_squared: float
     n_measurement_steps_r_squared: float
     data_used_to_extrapolate: List[GraphResourceInfo] = field(repr=False)
@@ -55,14 +69,18 @@ class ExtrapolatedGraphData(GraphData):
         return self.n_logical_qubits_r_squared
 
 
+# Alias for type of resource info returned by ExtrapolationResourceEstimator
 ExtrapolatedGraphResourceInfo = ResourceInfo[ExtrapolatedGraphData]
 
 
 @dataclass
 class AzureExtra:
+    """Extra info relating to resource estimation on Azure."""
+
     depth: int
     cycle_time: float
     raw_data: dict
 
 
+# Alias for type of resource info returned by AzureResourceEstimator
 AzureResourceInfo = ResourceInfo[AzureExtra]

--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -1,0 +1,25 @@
+################################################################################
+# © Copyright 2022-2023 Zapata Computing Inc.
+################################################################################
+"""Data structures describing estimated resources and related info."""
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class ResourceInfo:
+    """Contains all resource estimated for a problem instance."""
+
+    code_distance: int
+    logical_error_rate: float
+    n_logical_qubits: int
+    n_nodes: int = field(repr=False)
+    n_t_gates: int = field(repr=False)
+    n_rotation_gates: int = field(repr=False)
+    n_physical_qubits: int
+    n_measurement_steps: int
+    total_time_in_seconds: float
+    max_decodable_distance: Optional[int] = field(repr=False)
+    decoder_total_energy_consumption: Optional[float]
+    decoder_power: Optional[float]
+    decoder_area: Optional[float]

--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -3,7 +3,7 @@
 ################################################################################
 """Data structures describing estimated resources and related info."""
 from dataclasses import dataclass, field
-from typing import Generic, Optional, TypeVar
+from typing import Generic, List, Optional, TypeVar
 
 TExtra = TypeVar("TExtra")
 
@@ -14,17 +14,6 @@ class DecoderInfo:
     power: float
     area: float
     max_decodable_distance: int = field(repr=False)
-
-
-@dataclass
-class GraphData:
-    """Contains minimal set of data to get a resource estimate for a graph."""
-
-    max_graph_degree: int
-    n_nodes: int
-    n_t_gates: int
-    n_rotation_gates: int
-    n_measurement_steps: int
 
 
 @dataclass
@@ -40,4 +29,23 @@ class ResourceInfo(Generic[TExtra]):
     extra: TExtra
 
 
+@dataclass
+class GraphData:
+    """Contains minimal set of data to get a resource estimate for a graph."""
+
+    max_graph_degree: int
+    n_nodes: int
+    n_t_gates: int
+    n_rotation_gates: int
+    n_measurement_steps: int
+
+
 GraphCompilationResourceInfo = ResourceInfo[GraphData]
+
+
+@dataclass
+class ExtrapolatedGraphData(GraphData):
+    n_logical_qubits_r_squared: float
+    n_measurement_steps_r_squared: float
+    data_used_to_extrapolate: List[GraphCompilationResourceInfo]
+    steps_to_extrapolate_to: int

--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -7,6 +7,14 @@ from typing import Optional
 
 
 @dataclass
+class DecoderInfo:
+    total_energy_consumption: float
+    power: float
+    area: float
+    max_decodable_distance: int = field(repr=False)
+
+
+@dataclass
 class ResourceInfo:
     """Contains all resource estimated for a problem instance."""
 
@@ -19,7 +27,4 @@ class ResourceInfo:
     n_physical_qubits: int
     n_measurement_steps: int
     total_time_in_seconds: float
-    max_decodable_distance: Optional[int] = field(repr=False)
-    decoder_total_energy_consumption: Optional[float]
-    decoder_power: Optional[float]
-    decoder_area: Optional[float]
+    decoder_info: Optional[DecoderInfo]

--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -3,7 +3,9 @@
 ################################################################################
 """Data structures describing estimated resources and related info."""
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Generic, Optional, TypeVar
+
+TExtra = TypeVar("TExtra")
 
 
 @dataclass
@@ -15,16 +17,27 @@ class DecoderInfo:
 
 
 @dataclass
-class ResourceInfo:
+class GraphData:
+    """Contains minimal set of data to get a resource estimate for a graph."""
+
+    max_graph_degree: int
+    n_nodes: int
+    n_t_gates: int
+    n_rotation_gates: int
+    n_measurement_steps: int
+
+
+@dataclass
+class ResourceInfo(Generic[TExtra]):
     """Contains all resource estimated for a problem instance."""
 
     code_distance: int
     logical_error_rate: float
     n_logical_qubits: int
-    n_nodes: int = field(repr=False)
-    n_t_gates: int = field(repr=False)
-    n_rotation_gates: int = field(repr=False)
     n_physical_qubits: int
-    n_measurement_steps: int
     total_time_in_seconds: float
     decoder_info: Optional[DecoderInfo]
+    extra: TExtra
+
+
+GraphCompilationResourceInfo = ResourceInfo[GraphData]

--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -56,3 +56,13 @@ class ExtrapolatedGraphData(GraphData):
 
 
 ExtrapolatedGraphResourceInfo = ResourceInfo[ExtrapolatedGraphData]
+
+
+@dataclass
+class AzureExtra:
+    depth: int
+    cycle_time: float
+    raw_data: dict
+
+
+AzureResourceInfo = ResourceInfo[AzureExtra]

--- a/src/benchq/resource_estimation/azure.py
+++ b/src/benchq/resource_estimation/azure.py
@@ -11,8 +11,7 @@ from orquestra.integrations.qiskit.conversions import export_to_qiskit
 from orquestra.quantum.circuits import Circuit
 from qiskit.tools.monitor import job_monitor
 
-from ..data_structures import AzureExtra, AzureResourceInfo
-from ..data_structures.hardware_architecture_models import BasicArchitectureModel
+from ..data_structures import AzureExtra, AzureResourceInfo, BasicArchitectureModel
 
 
 def _azure_result_to_resource_info(job_results: dict) -> AzureResourceInfo:

--- a/src/benchq/resource_estimation/azure.py
+++ b/src/benchq/resource_estimation/azure.py
@@ -11,34 +11,25 @@ from orquestra.integrations.qiskit.conversions import export_to_qiskit
 from orquestra.quantum.circuits import Circuit
 from qiskit.tools.monitor import job_monitor
 
-from ..data_structures import ErrorBudget, QuantumProgram
+from ..data_structures import AzureExtra, AzureResourceInfo
 from ..data_structures.hardware_architecture_models import BasicArchitectureModel
-
-
-@dataclass
-class AzureResourceInfo:
-    physical_qubit_count: int
-    logical_qubit_count: int
-    total_time: float
-    depth: int
-    distance: int
-    cycle_time: float
-    logical_error_rate: float
-    raw_data: dict
 
 
 def _azure_result_to_resource_info(job_results: dict) -> AzureResourceInfo:
     return AzureResourceInfo(
-        physical_qubit_count=job_results["physicalCounts"]["physicalQubits"],
-        logical_qubit_count=job_results["physicalCounts"]["breakdown"][
+        n_physical_qubits=job_results["physicalCounts"]["physicalQubits"],
+        n_logical_qubits=job_results["physicalCounts"]["breakdown"][
             "algorithmicLogicalQubits"
         ],
-        total_time=job_results["physicalCounts"]["runtime_in_s"],
-        depth=job_results["physicalCounts"]["breakdown"]["algorithmicLogicalDepth"],
-        distance=job_results["logicalQubit"]["codeDistance"],
-        cycle_time=job_results["logicalQubit"]["logicalCycleTime"],
+        total_time_in_seconds=job_results["physicalCounts"]["runtime_in_s"],
+        code_distance=job_results["logicalQubit"]["codeDistance"],
         logical_error_rate=job_results["errorBudget"]["logical"],
-        raw_data=job_results,
+        decoder_info=None,
+        extra=AzureExtra(
+            cycle_time=job_results["logicalQubit"]["logicalCycleTime"],
+            depth=job_results["physicalCounts"]["breakdown"]["algorithmicLogicalDepth"],
+            raw_data=job_results,
+        ),
     )
 
 

--- a/src/benchq/resource_estimation/graph/automatic_resource_estimator.py
+++ b/src/benchq/resource_estimation/graph/automatic_resource_estimator.py
@@ -5,7 +5,12 @@ from typing import Any, Optional
 
 import numpy as np
 
-from ...data_structures import AlgorithmImplementation, DecoderModel, QuantumProgram
+from ...data_structures import (
+    AlgorithmImplementation,
+    DecoderModel,
+    QuantumProgram,
+    ResourceInfo,
+)
 from ...data_structures.hardware_architecture_models import BasicArchitectureModel
 from .default_pipelines import (
     run_fast_extrapolation_estimate,
@@ -13,7 +18,7 @@ from .default_pipelines import (
     run_precise_extrapolation_estimate,
     run_precise_graph_estimate,
 )
-from .graph_estimator import GraphResourceEstimator, ResourceInfo
+from .graph_estimator import GraphResourceEstimator
 
 LARGEST_GRAPH_TOLERANCE = 1e8
 DEFAULT_STEPS_TO_EXTRAPOLATE_FROM = [1, 2, 3]

--- a/src/benchq/resource_estimation/graph/customizable_pipelines.py
+++ b/src/benchq/resource_estimation/graph/customizable_pipelines.py
@@ -1,11 +1,9 @@
 from copy import copy
 from dataclasses import replace
 
-from benchq.data_structures.resource_info import ExtrapolatedGraphResourceInfo
-
 from ...data_structures import (
     AlgorithmImplementation,
-    ExtrapolatedGraphData,
+    ExtrapolatedGraphResourceInfo,
     QuantumProgram,
 )
 from .extrapolation_estimator import ExtrapolationResourceEstimator

--- a/src/benchq/resource_estimation/graph/customizable_pipelines.py
+++ b/src/benchq/resource_estimation/graph/customizable_pipelines.py
@@ -1,11 +1,14 @@
 from copy import copy
 from dataclasses import replace
 
-from ...data_structures import AlgorithmImplementation, QuantumProgram
-from .extrapolation_estimator import (
-    ExtrapolatedResourceInfo,
-    ExtrapolationResourceEstimator,
+from benchq.data_structures.resource_info import ExtrapolatedGraphResourceInfo
+
+from ...data_structures import (
+    AlgorithmImplementation,
+    ExtrapolatedGraphData,
+    QuantumProgram,
 )
+from .extrapolation_estimator import ExtrapolationResourceEstimator
 
 
 def run_custom_resource_estimation_pipeline(
@@ -27,7 +30,7 @@ def run_custom_extrapolation_pipeline(
     algorithm_description: AlgorithmImplementation,
     estimator: ExtrapolationResourceEstimator,
     transformers,
-) -> ExtrapolatedResourceInfo:
+) -> ExtrapolatedGraphResourceInfo:
     synthesis_accuracy_for_each_rotation = 1 - (
         1 - algorithm_description.error_budget.synthesis_failure_tolerance
     ) ** (1 / algorithm_description.program.n_rotation_gates)

--- a/src/benchq/resource_estimation/graph/default_pipelines.py
+++ b/src/benchq/resource_estimation/graph/default_pipelines.py
@@ -1,16 +1,18 @@
 from typing import List, Optional
 
 from ...compilation import get_algorithmic_graph_from_Jabalizer
-from ...data_structures import AlgorithmImplementation, DecoderModel, ResourceInfo
+from ...data_structures import (
+    AlgorithmImplementation,
+    DecoderModel,
+    ExtrapolatedGraphResourceInfo,
+    ResourceInfo,
+)
 from ...data_structures.hardware_architecture_models import BasicArchitectureModel
 from .customizable_pipelines import (
     run_custom_extrapolation_pipeline,
     run_custom_resource_estimation_pipeline,
 )
-from .extrapolation_estimator import (
-    ExtrapolatedResourceInfo,
-    ExtrapolationResourceEstimator,
-)
+from .extrapolation_estimator import ExtrapolationResourceEstimator
 from .graph_estimator import GraphResourceEstimator
 from .transformers import create_big_graph_from_subcircuits, synthesize_clifford_t
 
@@ -95,7 +97,7 @@ def run_precise_extrapolation_estimate(
     steps_to_extrapolate_from: List[int],
     decoder_model: Optional[DecoderModel] = None,
     n_measurement_steps_fit_type: str = "logarithmic",
-) -> ExtrapolatedResourceInfo:
+) -> ExtrapolatedGraphResourceInfo:
     """Run a faster resource estimate that's based on extrapolating from smaller
     circuits.
 
@@ -138,7 +140,7 @@ def run_fast_extrapolation_estimate(
     steps_to_extrapolate_from: List[int],
     decoder_model: Optional[DecoderModel] = None,
     n_measurement_steps_fit_type: str = "logarithmic",
-) -> ExtrapolatedResourceInfo:
+) -> ExtrapolatedGraphResourceInfo:
     """The fastest resource estimate method, but also the least accurate one.
 
     Run a resource estimate by creating a part graph created by of the full

--- a/src/benchq/resource_estimation/graph/default_pipelines.py
+++ b/src/benchq/resource_estimation/graph/default_pipelines.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from ...compilation import get_algorithmic_graph_from_Jabalizer
-from ...data_structures import AlgorithmImplementation, DecoderModel
+from ...data_structures import AlgorithmImplementation, DecoderModel, ResourceInfo
 from ...data_structures.hardware_architecture_models import BasicArchitectureModel
 from .customizable_pipelines import (
     run_custom_extrapolation_pipeline,
@@ -11,7 +11,7 @@ from .extrapolation_estimator import (
     ExtrapolatedResourceInfo,
     ExtrapolationResourceEstimator,
 )
-from .graph_estimator import GraphResourceEstimator, ResourceInfo
+from .graph_estimator import GraphResourceEstimator
 from .transformers import create_big_graph_from_subcircuits, synthesize_clifford_t
 
 

--- a/src/benchq/resource_estimation/graph/extrapolation_estimator.py
+++ b/src/benchq/resource_estimation/graph/extrapolation_estimator.py
@@ -1,12 +1,17 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from math import ceil
 from typing import List, Optional
 
 import numpy as np
 
-from ...data_structures import AlgorithmImplementation, DecoderModel, QuantumProgram
+from ...data_structures import (
+    AlgorithmImplementation,
+    DecoderModel,
+    QuantumProgram,
+    ResourceInfo,
+)
 from ...data_structures.hardware_architecture_models import BasicArchitectureModel
-from .graph_estimator import GraphData, GraphResourceEstimator, ResourceInfo
+from .graph_estimator import GraphData, GraphResourceEstimator
 
 
 @dataclass
@@ -67,7 +72,7 @@ class ExtrapolationResourceEstimator(GraphResourceEstimator):
                 n_measurement_steps_r_squared,
             ) = _get_logarithmic_extrapolation(
                 self.steps_to_extrapolate_from,
-                np.array([d.n_measurement_steps for d in data]),
+                np.array([d.extra.n_measurement_steps for d in data]),
                 steps_to_extrapolate_to,
             )
         elif self.n_measurement_steps_fit_type == "linear":
@@ -76,7 +81,7 @@ class ExtrapolationResourceEstimator(GraphResourceEstimator):
                 n_measurement_steps_r_squared,
             ) = _get_linear_extrapolation(
                 self.steps_to_extrapolate_from,
-                np.array([d.n_measurement_steps for d in data]),
+                np.array([d.extra.n_measurement_steps for d in data]),
                 steps_to_extrapolate_to,
             )
         else:
@@ -109,10 +114,9 @@ class ExtrapolationResourceEstimator(GraphResourceEstimator):
         )
         return ExtrapolatedResourceInfo(
             n_logical_qubits=resource_info.n_logical_qubits,
-            n_measurement_steps=resource_info.n_measurement_steps,
-            n_nodes=algorithm_description.program.n_nodes,
-            n_t_gates=resource_info.n_t_gates,
-            n_rotation_gates=resource_info.n_rotation_gates,
+            extra=replace(
+                resource_info.extra, n_nodes=algorithm_description.program.n_nodes
+            ),
             code_distance=resource_info.code_distance,
             logical_error_rate=resource_info.logical_error_rate,
             total_time_in_seconds=resource_info.total_time_in_seconds,

--- a/src/benchq/resource_estimation/graph/extrapolation_estimator.py
+++ b/src/benchq/resource_estimation/graph/extrapolation_estimator.py
@@ -4,16 +4,15 @@ from typing import List, Optional
 
 import numpy as np
 
-from benchq.data_structures.resource_info import ExtrapolatedGraphResourceInfo
-
 from ...data_structures import (
     AlgorithmImplementation,
+    BasicArchitectureModel,
     DecoderModel,
     ExtrapolatedGraphData,
+    ExtrapolatedGraphResourceInfo,
     QuantumProgram,
     ResourceInfo,
 )
-from ...data_structures.hardware_architecture_models import BasicArchitectureModel
 from .graph_estimator import GraphResourceEstimator
 
 

--- a/src/benchq/resource_estimation/graph/extrapolation_estimator.py
+++ b/src/benchq/resource_estimation/graph/extrapolation_estimator.py
@@ -117,10 +117,7 @@ class ExtrapolationResourceEstimator(GraphResourceEstimator):
             logical_error_rate=resource_info.logical_error_rate,
             total_time_in_seconds=resource_info.total_time_in_seconds,
             n_physical_qubits=resource_info.n_physical_qubits,
-            decoder_total_energy_consumption=resource_info.decoder_total_energy_consumption,  # noqa: E501
-            decoder_power=resource_info.decoder_power,
-            decoder_area=resource_info.decoder_area,
-            max_decodable_distance=resource_info.max_decodable_distance,
+            decoder_info=resource_info.decoder_info,
             n_logical_qubits_r_squared=extrapolated_info.max_graph_degree_r_squared,
             n_measurement_steps_r_squared=extrapolated_info.n_measurement_steps_r_squared,  # noqa: E501
             data_used_to_extrapolate=data,

--- a/src/benchq/resource_estimation/graph/graph_estimator.py
+++ b/src/benchq/resource_estimation/graph/graph_estimator.py
@@ -10,9 +10,9 @@ from ...data_structures import (
     AlgorithmImplementation,
     DecoderInfo,
     DecoderModel,
-    GraphCompilationResourceInfo,
     GraphData,
     GraphPartition,
+    GraphResourceInfo,
 )
 from ...data_structures.hardware_architecture_models import BasicArchitectureModel
 from ..magic_state_distillation import get_specs_for_t_state_widget
@@ -118,7 +118,7 @@ class GraphResourceEstimator:
         self,
         graph_data: GraphData,
         algorithm_description: AlgorithmImplementation,
-    ) -> GraphCompilationResourceInfo:
+    ) -> GraphResourceInfo:
         if graph_data.n_rotation_gates != 0:
             per_gate_synthesis_accuracy = 1 - (
                 1 - algorithm_description.error_budget.synthesis_failure_tolerance
@@ -203,7 +203,7 @@ class GraphResourceEstimator:
         else:
             decoder_info = None
 
-        return GraphCompilationResourceInfo(
+        return GraphResourceInfo(
             code_distance=code_distance,
             logical_error_rate=total_logical_error_rate,
             # estimate the number of logical qubits using max node degree
@@ -216,7 +216,7 @@ class GraphResourceEstimator:
 
     def estimate(
         self, algorithm_description: AlgorithmImplementation
-    ) -> GraphCompilationResourceInfo:
+    ) -> GraphResourceInfo:
         assert isinstance(algorithm_description.program, GraphPartition)
         if len(algorithm_description.program.subgraphs) == 1:
             graph_data = self._get_graph_data_for_single_graph(

--- a/src/benchq/resource_estimation/graph/graph_estimator.py
+++ b/src/benchq/resource_estimation/graph/graph_estimator.py
@@ -8,6 +8,7 @@ from graph_state_generation.substrate_scheduler import TwoRowSubstrateScheduler
 
 from ...data_structures import (
     AlgorithmImplementation,
+    DecoderInfo,
     DecoderModel,
     GraphPartition,
     ResourceInfo,
@@ -203,11 +204,14 @@ class GraphResourceEstimator:
                 code_distance
             )
             max_decodable_distance = self.find_max_decodable_distance()
+            decoder_info = DecoderInfo(
+                total_energy_consumption=decoder_total_energy_consumption,
+                power=decoder_power,
+                area=decoder_area,
+                max_decodable_distance=max_decodable_distance,
+            )
         else:
-            decoder_total_energy_consumption = None
-            decoder_power = None
-            decoder_area = None
-            max_decodable_distance = None
+            decoder_info = None
 
         return ResourceInfo(
             code_distance=code_distance,
@@ -220,10 +224,7 @@ class GraphResourceEstimator:
             n_measurement_steps=graph_data.n_measurement_steps,
             total_time_in_seconds=total_time_in_seconds,
             n_physical_qubits=n_physical_qubits,
-            decoder_total_energy_consumption=decoder_total_energy_consumption,
-            decoder_power=decoder_power,
-            decoder_area=decoder_area,
-            max_decodable_distance=max_decodable_distance,
+            decoder_info=decoder_info,
         )
 
     def estimate(self, algorithm_description: AlgorithmImplementation) -> ResourceInfo:

--- a/src/benchq/resource_estimation/graph/graph_estimator.py
+++ b/src/benchq/resource_estimation/graph/graph_estimator.py
@@ -6,7 +6,12 @@ import numpy as np
 from graph_state_generation.optimizers import greedy_stabilizer_measurement_scheduler
 from graph_state_generation.substrate_scheduler import TwoRowSubstrateScheduler
 
-from ...data_structures import AlgorithmImplementation, DecoderModel, GraphPartition
+from ...data_structures import (
+    AlgorithmImplementation,
+    DecoderModel,
+    GraphPartition,
+    ResourceInfo,
+)
 from ...data_structures.hardware_architecture_models import BasicArchitectureModel
 from ..magic_state_distillation import get_specs_for_t_state_widget
 
@@ -33,39 +38,6 @@ class GraphData:
     n_t_gates: int
     n_rotation_gates: int
     n_measurement_steps: int
-
-
-@dataclass
-class ResourceInfo:
-    """Contains all resource estimated for a problem instance."""
-
-    code_distance: int
-    logical_error_rate: float
-    n_logical_qubits: int
-    n_nodes: int
-    n_t_gates: int
-    n_rotation_gates: int
-    n_physical_qubits: int
-    n_measurement_steps: int
-    total_time_in_seconds: float
-    max_decodable_distance: Optional[int]
-    decoder_total_energy_consumption: Optional[float]
-    decoder_power: Optional[float]
-    decoder_area: Optional[float]
-
-    def __repr__(self):
-        necessary_info = [
-            "code_distance",
-            "logical_error_rate",
-            "n_logical_qubits",
-            "total_time_in_seconds",
-            "decoder_total_energy_consumption",
-            "decoder_power",
-            "decoder_area",
-            "n_measurement_steps",
-            "n_physical_qubits",
-        ]
-        return "\n".join(f"{info}: {getattr(self, info)}" for info in necessary_info)
 
 
 class GraphResourceEstimator:

--- a/src/benchq/resource_estimation/graph/graph_estimator.py
+++ b/src/benchq/resource_estimation/graph/graph_estimator.py
@@ -10,8 +10,9 @@ from ...data_structures import (
     AlgorithmImplementation,
     DecoderInfo,
     DecoderModel,
+    GraphCompilationResourceInfo,
+    GraphData,
     GraphPartition,
-    ResourceInfo,
 )
 from ...data_structures.hardware_architecture_models import BasicArchitectureModel
 from ..magic_state_distillation import get_specs_for_t_state_widget
@@ -28,17 +29,6 @@ def substrate_scheduler(graph: nx.Graph) -> TwoRowSubstrateScheduler:
     )
     scheduler_only_compiler.run()
     return scheduler_only_compiler
-
-
-@dataclass
-class GraphData:
-    """Contains minimal set of data to get a resource estimate for a graph."""
-
-    max_graph_degree: int
-    n_nodes: int
-    n_t_gates: int
-    n_rotation_gates: int
-    n_measurement_steps: int
 
 
 class GraphResourceEstimator:
@@ -128,7 +118,7 @@ class GraphResourceEstimator:
         self,
         graph_data: GraphData,
         algorithm_description: AlgorithmImplementation,
-    ) -> ResourceInfo:
+    ) -> GraphCompilationResourceInfo:
         if graph_data.n_rotation_gates != 0:
             per_gate_synthesis_accuracy = 1 - (
                 1 - algorithm_description.error_budget.synthesis_failure_tolerance
@@ -213,21 +203,20 @@ class GraphResourceEstimator:
         else:
             decoder_info = None
 
-        return ResourceInfo(
+        return GraphCompilationResourceInfo(
             code_distance=code_distance,
             logical_error_rate=total_logical_error_rate,
             # estimate the number of logical qubits using max node degree
             n_logical_qubits=graph_data.max_graph_degree,
-            n_nodes=graph_data.n_nodes,
-            n_t_gates=graph_data.n_t_gates,
-            n_rotation_gates=graph_data.n_rotation_gates,
-            n_measurement_steps=graph_data.n_measurement_steps,
             total_time_in_seconds=total_time_in_seconds,
             n_physical_qubits=n_physical_qubits,
             decoder_info=decoder_info,
+            extra=graph_data,
         )
 
-    def estimate(self, algorithm_description: AlgorithmImplementation) -> ResourceInfo:
+    def estimate(
+        self, algorithm_description: AlgorithmImplementation
+    ) -> GraphCompilationResourceInfo:
         assert isinstance(algorithm_description.program, GraphPartition)
         if len(algorithm_description.program.subgraphs) == 1:
             graph_data = self._get_graph_data_for_single_graph(

--- a/src/benchq/resource_estimation/graph/graph_estimator.py
+++ b/src/benchq/resource_estimation/graph/graph_estimator.py
@@ -8,13 +8,13 @@ from graph_state_generation.substrate_scheduler import TwoRowSubstrateScheduler
 
 from ...data_structures import (
     AlgorithmImplementation,
+    BasicArchitectureModel,
     DecoderInfo,
     DecoderModel,
     GraphData,
     GraphPartition,
     GraphResourceInfo,
 )
-from ...data_structures.hardware_architecture_models import BasicArchitectureModel
 from ..magic_state_distillation import get_specs_for_t_state_widget
 
 INITIAL_SYNTHESIS_ACCURACY = 0.0001

--- a/src/benchq/vizualization_tools.py
+++ b/src/benchq/vizualization_tools.py
@@ -8,8 +8,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 
-from .data_structures import ResourceInfo
-from .resource_estimation.graph.extrapolation_estimator import ExtrapolatedResourceInfo
+from .data_structures import ExtrapolatedGraphResourceInfo, ResourceInfo
 
 
 def plot_graph_state_with_measurement_steps(
@@ -36,7 +35,7 @@ def plot_graph_state_with_measurement_steps(
 
 
 def plot_extrapolations(
-    info: ExtrapolatedResourceInfo,
+    info: ExtrapolatedGraphResourceInfo,
     steps_to_extrapolate_from: List[int],
     n_measurement_steps_fit_type: str = "logarithmic",
     exact_info: Optional[ResourceInfo] = None,
@@ -54,7 +53,9 @@ def plot_extrapolations(
         ["n_logical_qubits", "n_measurement_steps", "n_nodes"]
     ):
         x = np.array(steps_to_extrapolate_from)
-        y = np.array([getattr(d, property) for d in info.data_used_to_extrapolate])
+        y = np.array(
+            [getattr(d, property) for d in info.extra.data_used_to_extrapolate]
+        )
 
         # logarithmic extrapolation
         if (
@@ -74,7 +75,7 @@ def plot_extrapolations(
         ):
             x = np.exp(x)  # rescale the x values for plotting
 
-            all_x = np.arange(1, info.steps_to_extrapolate_to + 1, 1)
+            all_x = np.arange(1, info.extra.steps_to_extrapolate_to + 1, 1)
             axis[i].plot(
                 all_x,
                 m * np.log(all_x) + c,
@@ -83,21 +84,21 @@ def plot_extrapolations(
             )
         else:
             axis[i].plot(
-                [0, info.steps_to_extrapolate_to],
-                [c, m * info.steps_to_extrapolate_to + c],
+                [0, info.extra.steps_to_extrapolate_to],
+                [c, m * info.extra.steps_to_extrapolate_to + c],
                 "r",
                 label="fitted line",
             )
 
         axis[i].plot(x, y, "bo")
         axis[i].plot(
-            [info.steps_to_extrapolate_to],
+            [info.extra.steps_to_extrapolate_to],
             [getattr(info, property)],
             "ko",
         )
         if exact_info is not None:
             axis[i].plot(
-                [info.steps_to_extrapolate_to],
+                [info.extra.steps_to_extrapolate_to],
                 [getattr(exact_info, property)],
                 "go",
             )

--- a/src/benchq/vizualization_tools.py
+++ b/src/benchq/vizualization_tools.py
@@ -8,8 +8,8 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 
+from .data_structures import ResourceInfo
 from .resource_estimation.graph.extrapolation_estimator import ExtrapolatedResourceInfo
-from .resource_estimation.graph.graph_estimator import ResourceInfo
 
 
 def plot_graph_state_with_measurement_steps(

--- a/tests/benchq/resource_estimation/test_azure_re.py
+++ b/tests/benchq/resource_estimation/test_azure_re.py
@@ -8,8 +8,8 @@ from benchq.data_structures import (
     AlgorithmImplementation,
     BasicArchitectureModel,
     ErrorBudget,
+    get_program_from_circuit,
 )
-from benchq.data_structures.quantum_program import get_program_from_circuit
 from benchq.resource_estimation.azure import AzureResourceEstimator
 
 SKIP_AZURE = pytest.mark.skipif(

--- a/tests/benchq/resource_estimation/test_azure_re.py
+++ b/tests/benchq/resource_estimation/test_azure_re.py
@@ -4,7 +4,11 @@ import numpy as np
 import pytest
 from orquestra.quantum.circuits import CNOT, RZ, Circuit, H
 
-from benchq.data_structures import BASIC_SC_ARCHITECTURE_MODEL, ErrorBudget
+from benchq.data_structures import (
+    AlgorithmImplementation,
+    BasicArchitectureModel,
+    ErrorBudget,
+)
 from benchq.data_structures.quantum_program import get_program_from_circuit
 from benchq.resource_estimation.azure import AzureResourceEstimator
 
@@ -18,75 +22,86 @@ SKIP_AZURE = pytest.mark.skipif(
 @pytest.mark.skip(
     "It looks like Azure does not take information about the hardware into account"
 )
-def test_better_architecture_does_not_require_more_resources():
-    low_quality_architecture_model = BASIC_SC_ARCHITECTURE_MODEL(
+def test_better_architecture_does_not_require_more_resources() -> None:
+    low_quality_architecture_model = BasicArchitectureModel(
         physical_gate_error_rate=1e-4,
         physical_gate_time_in_seconds=1e-6,
     )
-    high_quality_architecture_model = BASIC_SC_ARCHITECTURE_MODEL(
+    high_quality_architecture_model = BasicArchitectureModel(
         physical_gate_error_rate=1e-3,
         physical_gate_time_in_seconds=1e-9,
     )
+
     # set circuit generation weight to 0
     error_budget = ErrorBudget.from_weights(1e-3, 0, 1, 1)
 
     quantum_program = get_program_from_circuit(
         Circuit([H(0), RZ(np.pi / 4)(0), CNOT(0, 1)])
     )
+
+    alg_impl = AlgorithmImplementation(
+        program=quantum_program, error_budget=error_budget, n_calls=1
+    )
+
     low_quality_azure_re = AzureResourceEstimator(
         hw_model=low_quality_architecture_model
     )
     high_quality_azure_re = AzureResourceEstimator(
         hw_model=high_quality_architecture_model
     )
-    low_quality_resource_estimates = low_quality_azure_re.estimate(
-        quantum_program, error_budget
-    )
-    high_quality_resource_estimates = high_quality_azure_re.estimate(
-        quantum_program, error_budget
+    low_quality_resource_estimates = low_quality_azure_re.estimate(alg_impl)
+
+    high_quality_resource_estimates = high_quality_azure_re.estimate(alg_impl)
+
+    assert (
+        low_quality_resource_estimates.n_physical_qubits
+        < high_quality_resource_estimates.n_physical_qubits
     )
     assert (
-        low_quality_resource_estimates.physical_qubit_count
-        < high_quality_resource_estimates.physical_qubit_count
+        low_quality_resource_estimates.code_distance
+        <= high_quality_resource_estimates.code_distance
     )
     assert (
-        low_quality_resource_estimates.distance
-        <= high_quality_resource_estimates.distance
-    )
-    assert (
-        low_quality_resource_estimates.total_time
-        < high_quality_resource_estimates.total_time
+        low_quality_resource_estimates.total_time_in_seconds
+        < high_quality_resource_estimates.total_time_in_seconds
     )
 
 
 @SKIP_AZURE
-def test_higher_error_budget_requires_less_resources():
+def test_higher_error_budget_requires_less_resources() -> None:
     low_failure_tolerance = 1e-5
     high_failure_tolerance = 1e-3
-
-    # set circuit generation weight to 0
-    low_error_budget = ErrorBudget.from_weights(low_failure_tolerance, 0, 1, 1)
-    high_error_budget = ErrorBudget.from_weights(high_failure_tolerance, 0, 1, 1)
 
     quantum_program = get_program_from_circuit(
         Circuit([H(0), RZ(np.pi / 4)(0), CNOT(0, 1)])
     )
+
+    # set circuit generation weight to 0
+    low_error_budget_impl = AlgorithmImplementation(
+        program=quantum_program,
+        error_budget=ErrorBudget.from_weights(low_failure_tolerance, 0, 1, 1),
+        n_calls=1,
+    )
+
+    high_error_budget_impl = AlgorithmImplementation(
+        program=quantum_program,
+        error_budget=ErrorBudget.from_weights(high_failure_tolerance, 0, 1, 1),
+        n_calls=1,
+    )
     azure_re = AzureResourceEstimator()
 
-    low_budget_resource_estimates = azure_re.estimate(quantum_program, low_error_budget)
-    high_budget_resource_estimates = azure_re.estimate(
-        quantum_program, high_error_budget
-    )
+    low_budget_resource_estimates = azure_re.estimate(low_error_budget_impl)
+    high_budget_resource_estimates = azure_re.estimate(high_error_budget_impl)
 
     assert (
-        low_budget_resource_estimates.physical_qubit_count
-        > high_budget_resource_estimates.physical_qubit_count
+        low_budget_resource_estimates.n_physical_qubits
+        > high_budget_resource_estimates.n_physical_qubits
     )
     assert (
-        low_budget_resource_estimates.distance
-        >= high_budget_resource_estimates.distance
+        low_budget_resource_estimates.code_distance
+        >= high_budget_resource_estimates.code_distance
     )
     assert (
-        low_budget_resource_estimates.total_time
-        > high_budget_resource_estimates.total_time
+        low_budget_resource_estimates.total_time_in_seconds
+        > high_budget_resource_estimates.total_time_in_seconds
     )

--- a/tests/benchq/resource_estimation/test_extrapolation_estimation.py
+++ b/tests/benchq/resource_estimation/test_extrapolation_estimation.py
@@ -112,31 +112,27 @@ def test_get_resource_estimations_for_small_program_gives_correct_results(
         transformers=transformers,
     )
 
-    attributes_to_compare_harshly = [
-        "n_nodes",
-        "total_time_in_seconds",
-        "n_physical_qubits",
-    ]
-    for attribute in attributes_to_compare_harshly:
-        assert np.isclose(
-            getattr(extrapolated_resource_estimates, attribute),
-            getattr(gsc_resource_estimates, attribute),
-            rtol=1e-1,
-        )
-    # assert that the number of measurement steps grows with the steps
-    attributes_to_compare_loosely = [
-        "n_logical_qubits",
-        "n_measurement_steps",
-        "code_distance",
-    ]
-    for attribute in attributes_to_compare_loosely:
-        assert (
-            abs(
-                getattr(extrapolated_resource_estimates, attribute)
-                - getattr(gsc_resource_estimates, attribute)
-            )
-            <= 3
-        )
+    def _results_to_compare_harshly(resource_info):
+        return {
+            "n_nodes": resource_info.extra.n_nodes,
+            "total_time_in_seconds": resource_info.total_time_in_seconds,
+            "n_physical_qubits": resource_info.n_physical_qubits,
+        }
+
+    assert _results_to_compare_harshly(
+        extrapolated_resource_estimates
+    ) == pytest.approx(_results_to_compare_harshly(gsc_resource_estimates), rel=1e-1)
+
+    def _results_to_compare_loosely(resource_info):
+        return {
+            "n_logical_qubits": resource_info.n_logical_qubits,
+            "n_measurement_steps": resource_info.extra.n_measurement_steps,
+            "code_distance": resource_info.code_distance,
+        }
+
+    assert _results_to_compare_loosely(
+        extrapolated_resource_estimates
+    ) == pytest.approx(_results_to_compare_loosely(gsc_resource_estimates), abs=3)
 
 
 @pytest.mark.parametrize(
@@ -199,18 +195,17 @@ def test_get_resource_estimations_for_large_program_gives_correct_results(
         transformers=transformers,
     )
 
-    attributes_to_compare_relatively = [
-        "n_nodes",
-        "total_time_in_seconds",
-        "n_physical_qubits",
-        "n_logical_qubits",
-    ]
-    for attribute in attributes_to_compare_relatively:
-        assert np.isclose(
-            getattr(extrapolated_resource_estimates, attribute),
-            getattr(gsc_resource_estimates, attribute),
-            rtol=1e-1,
-        )
+    def _results_to_compare_relatively(resource_info):
+        return {
+            "n_nodes": resource_info.extra.n_nodes,
+            "total_time_in_seconds": resource_info.total_time_in_seconds,
+            "n_physical_qubits": resource_info.n_physical_qubits,
+            "n_logical_qubits": resource_info.n_logical_qubits,
+        }
+
+    assert _results_to_compare_relatively(
+        extrapolated_resource_estimates
+    ) == pytest.approx(_results_to_compare_relatively(gsc_resource_estimates), rel=1e-1)
 
     assert (
         abs(
@@ -221,8 +216,8 @@ def test_get_resource_estimations_for_large_program_gives_correct_results(
     )
     assert (
         abs(
-            extrapolated_resource_estimates.n_measurement_steps
-            - gsc_resource_estimates.n_measurement_steps
+            extrapolated_resource_estimates.extra.n_measurement_steps
+            - gsc_resource_estimates.extra.n_measurement_steps
         )
         <= 10
     )

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -244,14 +244,5 @@ def test_get_resource_estimations_for_program_accounts_for_decoder():
         transformers=transformers,
     )
 
-    assert gsc_resource_estimates_no_decoder.max_decodable_distance is None
-    assert gsc_resource_estimates_no_decoder.decoder_area is None
-    assert gsc_resource_estimates_no_decoder.decoder_total_energy_consumption is None
-    assert gsc_resource_estimates_no_decoder.decoder_power is None
-
-    assert gsc_resource_estimates_with_decoder.max_decodable_distance is not None
-    assert gsc_resource_estimates_with_decoder.decoder_area is not None
-    assert (
-        gsc_resource_estimates_with_decoder.decoder_total_energy_consumption is not None
-    )
-    assert gsc_resource_estimates_with_decoder.decoder_power is not None
+    assert gsc_resource_estimates_no_decoder.decoder_info is None
+    assert gsc_resource_estimates_with_decoder.decoder_info is not None

--- a/tests/benchq/resource_estimation/test_graph_compilation.py
+++ b/tests/benchq/resource_estimation/test_graph_compilation.py
@@ -88,25 +88,26 @@ def test_get_resource_estimations_for_program_gives_correct_results(
     algorithm_description = AlgorithmImplementation(quantum_program, error_budget, 1)
 
     transformers = _get_transformers(use_delayed_gate_synthesis, error_budget)
-    gsc_resource_estimates = asdict(
-        run_custom_resource_estimation_pipeline(
-            algorithm_description,
-            estimator=GraphResourceEstimator(architecture_model),
-            transformers=transformers,
-        )
+    gsc_resource_estimates = run_custom_resource_estimation_pipeline(
+        algorithm_description,
+        estimator=GraphResourceEstimator(architecture_model),
+        transformers=transformers,
     )
 
     # Extract only keys that we want to compare
-    assert {
-        key: gsc_resource_estimates[key] for key in expected_results
-    } == expected_results
+    actual_results = {
+        "n_measurement_steps": gsc_resource_estimates.extra.n_measurement_steps,
+        "n_nodes": gsc_resource_estimates.extra.n_nodes,
+        "n_logical_qubits": gsc_resource_estimates.n_logical_qubits,
+    }
+
+    assert actual_results == expected_results
 
     # Note that error_budget is a bound for the sum of the gate synthesis error and
     # logical error. Therefore the expression below is a loose upper bound for the
     # logical error rate.
     assert (
-        gsc_resource_estimates["logical_error_rate"]
-        < error_budget.total_failure_tolerance
+        gsc_resource_estimates.logical_error_rate < error_budget.total_failure_tolerance
     )
 
 


### PR DESCRIPTION
> **Warning**
> DON'T MERGE THIS PR UNTIL SCRIPTS ARE UPATED
## Description

This PR unifies all classes storing resource info into a single generic class. The attributes common to all (or at least most) resource info classes were preserved in `ResourceInfo`, and the differing attributes were pushed to a separate `extra` field. Type of the `extra` field is the generic parameter of `ResourceInfo`.

For instance, for `AzureResourceInfo`, there exists a `AzureExtra` class storing things like raw data, and `AzureResourceInfo` is just equal to `ResourceInfo[AzureExtra]`.

The PR also fixes Azure tests and applies several minor style improvements.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
