### PR TITLE
Adding openfermion resource info

### DIFF
--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -86,15 +86,6 @@ class AzureExtra:
     raw_data: dict
 
 
-@dataclass
-class OpenFermionExtra:
-    """Extra info relating to resource estimation on Azure."""
-
-    depth: int
-    cycle_time: float
-    raw_data: dict
-
-
 # Alias for type of resource info returned by AzureResourceEstimator
 AzureResourceInfo = ResourceInfo[AzureExtra]
 

--- a/src/benchq/data_structures/resource_info.py
+++ b/src/benchq/data_structures/resource_info.py
@@ -5,6 +5,10 @@
 from dataclasses import dataclass, field
 from typing import Generic, List, Optional, TypeVar
 
+from openfermion.resource_estimates.surface_code_compilation.physical_costing import (
+    AlgorithmParameters,
+)
+
 TExtra = TypeVar("TExtra")
 
 
@@ -82,5 +86,17 @@ class AzureExtra:
     raw_data: dict
 
 
+@dataclass
+class OpenFermionExtra:
+    """Extra info relating to resource estimation on Azure."""
+
+    depth: int
+    cycle_time: float
+    raw_data: dict
+
+
 # Alias for type of resource info returned by AzureResourceEstimator
 AzureResourceInfo = ResourceInfo[AzureExtra]
+
+# Alias for type of resource info returned by OpenFermion
+OpenFermionResourceInfo = ResourceInfo[AlgorithmParameters]

--- a/src/benchq/resource_estimation/openfermion_re.py
+++ b/src/benchq/resource_estimation/openfermion_re.py
@@ -6,9 +6,12 @@ from typing import Any, Dict, Tuple
 import numpy as np
 from openfermion.resource_estimates import sf
 from openfermion.resource_estimates.surface_code_compilation.physical_costing import (
+    AlgorithmParameters,
+    CostEstimate,
     cost_estimator,
 )
 
+from benchq.data_structures.resource_info import OpenFermionResourceInfo
 from benchq.resource_estimation._compute_lambda_sf import compute_lambda
 
 
@@ -60,7 +63,7 @@ def get_single_factorized_qpe_resource_estimate(
     rank: int,
     allowable_phase_estimation_error: float = 0.001,
     bits_precision_state_prep: int = 10,
-) -> Dict[str, Any]:
+) -> OpenFermionResourceInfo:
     """Get the estimated resources for single factorized QPE as described in PRX Quantum
     2, 030305.
 
@@ -99,15 +102,18 @@ def get_single_factorized_qpe_resource_estimate(
         portion_of_bounding_box=1.0,
     )
 
-    physical_qubit_count = best_cost.physical_qubit_count
-    duration = best_cost.duration
-    print("Number of physical qubits is:", physical_qubit_count)
-    print("Runtime in hours is:", duration.seconds / 3600)
-    return {
-        # "logical_error_rate": final_logical_error_rate,
-        "total_time": duration.seconds,
-        "physical_qubit_count": physical_qubit_count,
-        # "min_viable_distance": min_viable_distance,
-        # "synthesis_error_rate": synthesis_error_rate,
-        # "resources_in_cells": resources_in_cells,
-    }
+    return _openfermion_result_to_resource_info(best_cost, best_params)
+
+
+def _openfermion_result_to_resource_info(
+    cost: CostEstimate, algorithm_parameters: AlgorithmParameters
+) -> OpenFermionResourceInfo:
+    return OpenFermionResourceInfo(
+        n_physical_qubits=cost.physical_qubit_count,
+        n_logical_qubits=algorithm_parameters.max_allocated_logical_qubits,
+        total_time_in_seconds=cost.duration.seconds,
+        code_distance=algorithm_parameters.logical_data_qubit_distance,
+        logical_error_rate=cost.algorithm_failure_probability,
+        decoder_info=None,
+        extra=algorithm_parameters,
+    )

--- a/tests/benchq/resource_estimation/test_openfermion_re.py
+++ b/tests/benchq/resource_estimation/test_openfermion_re.py
@@ -27,8 +27,7 @@ def test_physical_qubit_count_is_larger_than_number_of_spin_orbitals(
         h1, eri_full, 20
     )
     assert (
-        qpe_resource_estimates["physical_qubit_count"]
-        > 2 * mean_field_object._eri.shape[0]
+        qpe_resource_estimates.n_physical_qubits > 2 * mean_field_object._eri.shape[0]
     )
 
 


### PR DESCRIPTION
## Description

Currently, the OpenFermion resource estimator integration does not return the number of Toffoli gates. This pull request addresses this by introducing a `ResourceInfo` subclass for OpenFermion estimates that includes all the algorithm parameters returned by OpenFermion (including Toffoli count) in the `extra` attribute.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
