### PR TITLE
chore: bump orquestra quantum version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find_namespace:
 python_requires = >=3.8,!=3.9.7,<3.11
 
 install_requires =
-    orquestra-quantum==0.9.0
+    orquestra-quantum==0.10.0
     orquestra-vqa==0.8.0
     orquestra-qiskit==0.9.0
     orquestra-cirq @ git+https://github.com/zapatacomputing/orquestra-cirq

--- a/src/benchq/problem_embeddings/_trotter.py
+++ b/src/benchq/problem_embeddings/_trotter.py
@@ -11,7 +11,7 @@ from ..data_structures import QuantumProgram
 
 def get_trotter_circuit(hamiltonian, evolution_time, number_of_steps):
     return time_evolution(
-        hamiltonian, time=evolution_time, trotter_order=number_of_steps
+        hamiltonian, time=evolution_time, n_steps=number_of_steps
     )
 
 

--- a/src/benchq/problem_embeddings/_trotter.py
+++ b/src/benchq/problem_embeddings/_trotter.py
@@ -22,7 +22,7 @@ def get_trotter_program(
     # NOTE:
     # `trotter_order` is named badly in `time_evolution`.
     # It actually is number of trotter steps
-    circuit = time_evolution(hamiltonian, time=time_per_step, trotter_order=1)
+    circuit = time_evolution(hamiltonian, time=time_per_step, n_steps=1)
 
     def subrountines_for_trotter(steps):
         return [0] * steps

--- a/src/benchq/problem_embeddings/_trotter.py
+++ b/src/benchq/problem_embeddings/_trotter.py
@@ -10,9 +10,7 @@ from ..data_structures import QuantumProgram
 
 
 def get_trotter_circuit(hamiltonian, evolution_time, number_of_steps):
-    return time_evolution(
-        hamiltonian, time=evolution_time, n_steps=number_of_steps
-    )
+    return time_evolution(hamiltonian, time=evolution_time, n_steps=number_of_steps)
 
 
 def get_trotter_program(


### PR DESCRIPTION
## Description

- Context: orquestra-core requires orquestra-quantum=0.10.0. Installing benchq and orquestra-core together causes issues
- A [bug was caused](https://github.com/zapatacomputing/benchq/actions/runs/5269053218/jobs/9526621412?pr=84) in bumping to 0.10.0 because of [changing trotter_order to n_steps in time_evolution](https://github.com/zapatacomputing/orquestra-quantum/commit/78d4a682cf153e7c2197a3dcf428d4375cdf0d41). This PR also updates that syntax here in benchq

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
