### PR TITLE
Implement new example workflow without pipelines

### DIFF
--- a/examples/ex_6_orquestra_customized/defs.py
+++ b/examples/ex_6_orquestra_customized/defs.py
@@ -1,0 +1,109 @@
+"""Workflow and task definitions.
+
+To run this on Orquestra or locally use ``run.py`` script in the same directory.
+"""
+from dataclasses import replace
+from typing import List
+
+from orquestra import sdk
+
+from benchq.algorithms.time_evolution import qsp_time_evolution_algorithm
+from benchq.data_structures import (
+    BASIC_ION_TRAP_ARCHITECTURE_MODEL,
+    BASIC_SC_ARCHITECTURE_MODEL,
+    AlgorithmImplementation,
+    BasicArchitectureModel,
+    ErrorBudget,
+    GraphResourceInfo,
+)
+from benchq.problem_ingestion import get_vlasov_hamiltonian
+from benchq.resource_estimation.graph import (
+    GraphResourceEstimator,
+    create_big_graph_from_subcircuits,
+    simplify_rotations,
+)
+
+task = sdk.task(
+    source_import=sdk.GitImport.infer(), resources=sdk.Resources(memory="4Gi")
+)
+
+
+@task
+def get_algorithm_implementation(
+    problem_size: int, evolution_time: float, error_budget: ErrorBudget
+) -> AlgorithmImplementation:
+    """Task producing algorithm implementation.
+
+    The produced algorithm is QSP time evolution algorithm, with given evolution
+    time and error budget. The operator used is vlasov_hamiltonian of given size.
+    """
+    return qsp_time_evolution_algorithm(
+        hamiltonian=get_vlasov_hamiltonian(N=problem_size, k=2.0, alpha=0.0, nu=0),
+        time=evolution_time,
+        failure_tolerance=error_budget.total_failure_tolerance,
+    )
+
+
+@task
+def transpile(
+    algorithm_implementation: AlgorithmImplementation,
+) -> AlgorithmImplementation:
+    """Transpile algorithm implementation into a graph representationp.
+
+    The transpilation has two steps:
+
+    1. Simplifying rotations
+    2. Converting the QuantumProgram of the algorithm into a graph representation.
+    """
+    return replace(
+        algorithm_implementation,
+        program=create_big_graph_from_subcircuits()(
+            simplify_rotations(algorithm_implementation.program)
+        ),
+    )
+
+
+@task
+def estimate_resources(
+    algorithm_implementation: AlgorithmImplementation,
+    architecture_model: BasicArchitectureModel,
+) -> GraphResourceInfo:
+    """Estimate resources for algorithm impl., assuming given architecture_model."""
+    return GraphResourceEstimator(hw_model=architecture_model).estimate(
+        algorithm_implementation
+    )
+
+
+@sdk.workflow
+def estimation_workflow() -> List[GraphResourceInfo]:
+    """The workflow for estimating resources.
+
+    The workflow does the following:
+    1. Creates algorithm description.
+    2. Transpiles it into a graph representation.
+    3. Defines two architecture models.
+    4. Estimates the resources for the constructed algorithm implementation assuming
+       the defined hardware models.
+
+    The last step can be parallelized.
+
+    The workflow does not use pieplines defined in benchq, and hence the graph
+    compilation is not repeated for each hardware model, bur rather computed
+    once and reused.
+    """
+    algorithm = get_algorithm_implementation(
+        problem_size=2,
+        evolution_time=5.0,
+        error_budget=ErrorBudget.from_even_split(total_failure_tolerance=1e-3),
+    )
+
+    architecture_models = [
+        BASIC_SC_ARCHITECTURE_MODEL,
+        BASIC_ION_TRAP_ARCHITECTURE_MODEL,
+    ]
+
+    transpiled_algorithm = transpile(algorithm)
+
+    return [
+        estimate_resources(transpiled_algorithm, model) for model in architecture_models
+    ]

--- a/examples/ex_6_orquestra_customized/defs.py
+++ b/examples/ex_6_orquestra_customized/defs.py
@@ -14,7 +14,9 @@ from benchq.data_structures import (
     AlgorithmImplementation,
     BasicArchitectureModel,
     ErrorBudget,
+    GraphPartition,
     GraphResourceInfo,
+    QuantumProgram,
 )
 from benchq.problem_ingestion import get_vlasov_hamiltonian
 from benchq.resource_estimation.graph import (
@@ -22,6 +24,7 @@ from benchq.resource_estimation.graph import (
     create_big_graph_from_subcircuits,
     simplify_rotations,
 )
+
 task_deps = [
     sdk.PythonImports(
         "pyscf==2.2.0", "openfermionpyscf==0.5", "stim==1.10", "juliapkg"
@@ -32,7 +35,10 @@ task_deps = [
 ]
 
 task = sdk.task(
-    source_import=sdk.InlineImport(), dependency_imports=task_deps, resources=sdk.Resources(memory="4Gi"), custom_image="hub.nexus.orquestra.io/users/james.clark/benchq-ce:0.50.0"
+    source_import=sdk.InlineImport(),
+    dependency_imports=task_deps,
+    resources=sdk.Resources(memory="4Gi"),
+    custom_image="hub.nexus.orquestra.io/users/james.clark/benchq-ce:0.50.0",
 )
 
 
@@ -54,8 +60,8 @@ def get_algorithm_implementation(
 
 @task
 def transpile(
-    algorithm_implementation: AlgorithmImplementation,
-) -> AlgorithmImplementation:
+    algorithm_implementation: AlgorithmImplementation[QuantumProgram],
+) -> AlgorithmImplementation[GraphPartition]:
     """Transpile algorithm implementation into a graph representationp.
 
     The transpilation has two steps:

--- a/examples/ex_6_orquestra_customized/defs.py
+++ b/examples/ex_6_orquestra_customized/defs.py
@@ -22,9 +22,17 @@ from benchq.resource_estimation.graph import (
     create_big_graph_from_subcircuits,
     simplify_rotations,
 )
+task_deps = [
+    sdk.PythonImports(
+        "pyscf==2.2.0", "openfermionpyscf==0.5", "stim==1.10", "juliapkg"
+    ),
+    sdk.GithubImport(
+        "zapatacomputing/benchq",
+    ),
+]
 
 task = sdk.task(
-    source_import=sdk.GitImport.infer(), resources=sdk.Resources(memory="4Gi")
+    source_import=sdk.InlineImport(), dependency_imports=task_deps, resources=sdk.Resources(memory="4Gi"), custom_image="hub.nexus.orquestra.io/users/james.clark/benchq-ce:0.50.0"
 )
 
 
@@ -74,7 +82,7 @@ def estimate_resources(
     )
 
 
-@sdk.workflow
+@sdk.workflow(resources=sdk.Resources(memory="8Gi", nodes=2))
 def estimation_workflow() -> List[GraphResourceInfo]:
     """The workflow for estimating resources.
 

--- a/examples/ex_6_orquestra_customized/run.py
+++ b/examples/ex_6_orquestra_customized/run.py
@@ -1,0 +1,51 @@
+"""Script for running estimation workflow.
+
+Synopsis:
+usage: run.py [-h] target
+
+positional arguments:
+  target      where to run the workflow (e.g. in_process or name of the orquestra cluster). This argument is passed to Workflow.run method.
+
+options:
+  -h, --help  show this help message and exit
+
+This file uses relative imports, and hence has to be launched as module from outside
+of its parent directory. For intsance, to launch it from benchq main directory, run:
+
+python -m examples.ex_6_orquestra_customized.run in_process
+"""
+import argparse
+from time import sleep
+
+from orquestra.sdk.schema.workflow_run import State
+
+from .defs import estimation_workflow
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "target",
+        help=(
+            "where to run the workflow (e.g. in_process or name of the orquestra cluster). "
+            "This argument is passed to Workflow.run method."
+        ),
+        type=str,
+    )
+
+    args = parser.parse_args()
+
+    wf = estimation_workflow()
+
+    wf_run = wf.run(args.target)
+    print(f"Workflow {wf_run.run_id} submitted!")
+
+    while (state := wf_run.get_status()) in (State.WAITING, State.RUNNING):
+        print(f"State: {state}")
+        sleep(1)
+
+    print(wf_run.get_results())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ex_6_orquestra_customized/run.py
+++ b/examples/ex_6_orquestra_customized/run.py
@@ -40,9 +40,7 @@ def main():
     wf_run = wf.run(args.target)
     print(f"Workflow {wf_run.run_id} submitted!")
 
-    while (state := wf_run.get_status()) in (State.WAITING, State.RUNNING):
-        print(f"State: {state}")
-        sleep(1)
+    wf_run.wait_until_finished()
 
     print(wf_run.get_results())
 

--- a/src/benchq/data_structures/algorithm_implemenation.py
+++ b/src/benchq/data_structures/algorithm_implemenation.py
@@ -1,14 +1,16 @@
 from dataclasses import dataclass
-from typing import Union
+from typing import Generic, TypeVar, Union
 
 from .error_budget import ErrorBudget
 from .graph_partition import GraphPartition
 from .quantum_program import QuantumProgram, get_program_from_circuit
 
+T = TypeVar("T", QuantumProgram, GraphPartition)
+
 
 @dataclass
-class AlgorithmImplementation:
-    program: Union[QuantumProgram, GraphPartition]
+class AlgorithmImplementation(Generic[T]):
+    program: T
     error_budget: ErrorBudget
     n_calls: int
 


### PR DESCRIPTION
## Description

This pull request adds a new workflow example that runs resource estimation without using benchq pipelines. Instead of using pipelines, the workflow manually transpiles algorithm implementation into a graph representation, and then uses this graph representations to compute resource estimations two times.

Additionally, this PR makes `AlgorithmImplementation` class generic in its `program` field. This change does not affect benchq's behaviour at runtime, but makes the workflow much more readable, because one can see that the transpilation task transforms `AlgorithmImplementation[QuantumProgram]` into `AlgorithmImplementation[GraphPartition]`.


## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
- [X] I have included test cases validating introduced feature/fix.
- [X] I have updated documentation.
