### PR TITLE
Make BasicArchitectureModel a dataclass

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ dev =
 pyscf =
     pyscf~=2.2.0
     openfermionpyscf==0.5
+    scipy<1.11.0
 
 azure =
     benchq[pyscf]

--- a/src/benchq/data_structures/hardware_architecture_models.py
+++ b/src/benchq/data_structures/hardware_architecture_models.py
@@ -4,12 +4,11 @@
 # WARNING! SIMPLE MODELING AHEAD! ABANDON NUANCE ALL YE WHO ENTER HERE!
 
 
-class ABCArchitectureModel:
-    def __init__(self):
-        pass
+from dataclasses import dataclass
 
 
-class BasicArchitectureModel(ABCArchitectureModel):
+@dataclass
+class BasicArchitectureModel:
     """Basic Architecture model meant to serve as a base class for the
     other basic architecture models. WARNING! Running a resource estimate
     with this architecture model will fail as, you need to choose an ION
@@ -25,21 +24,8 @@ class BasicArchitectureModel(ABCArchitectureModel):
             surface code cycle.
     """
 
-    def __init__(
-        self,
-        physical_qubit_error_rate,
-        surface_code_cycle_time_in_seconds,
-    ):
-        self.physical_qubit_error_rate = physical_qubit_error_rate
-        self.surface_code_cycle_time_in_seconds = surface_code_cycle_time_in_seconds
-
-    def __eq__(self, __value: object) -> bool:
-        assert isinstance(__value, BasicArchitectureModel)
-        return (
-            self.physical_qubit_error_rate == __value.physical_qubit_error_rate
-            and self.surface_code_cycle_time_in_seconds
-            == __value.surface_code_cycle_time_in_seconds
-        )
+    physical_qubit_error_rate: float
+    surface_code_cycle_time_in_seconds: float
 
 
 BASIC_ION_TRAP_ARCHITECTURE_MODEL = BasicArchitectureModel(1e-4, 1e-5)


### PR DESCRIPTION
## Description

This simply makes `BasicArchitectureModel` a dataclass to address a problem reported by @1ethanhansen.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
