### PR TITLE
feat: turn DecoderModel into a dataclass

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ dev =
 
 pyscf =
     pyscf~=2.2.0
+    scipy<1.11.0
     openfermionpyscf==0.5
 
 azure =

--- a/src/benchq/data_structures/decoder.py
+++ b/src/benchq/data_structures/decoder.py
@@ -1,8 +1,8 @@
 ################################################################################
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
-from dataclasses import dataclass
 import warnings
+from dataclasses import dataclass
 from typing import Dict
 
 import numpy as np

--- a/src/benchq/data_structures/decoder.py
+++ b/src/benchq/data_structures/decoder.py
@@ -1,12 +1,14 @@
 ################################################################################
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
+from dataclasses import dataclass
 import warnings
 from typing import Dict
 
 import numpy as np
 
 
+@dataclass
 class DecoderModel:
     """Class representing decoder model for belief-propagation decoder.
 
@@ -17,17 +19,10 @@ class DecoderModel:
     belief-propagation.
     """
 
-    def __init__(
-        self,
-        power_table: Dict[int, float],
-        area_table: Dict[int, float],
-        delay_table: Dict[int, float],
-        distance_cap: int = 31,
-    ):
-        self.power_table = power_table
-        self.area_table = area_table
-        self.delay_table = delay_table
-        self.distance_cap = distance_cap
+    power_table: Dict[int, float]
+    area_table: Dict[int, float]
+    delay_table: Dict[int, float]
+    distance_cap: int = 31
 
     def power(self, distance: int) -> float:
         """Calculates the power (in W) that it will take to decode the code


### PR DESCRIPTION
This will be useful for ZQS-1327

## Description

- Context: making DecoderModel a dataclass is useful for [ZQS-1327](https://github.com/zapatacomputing/benchq/tree/ZQS-1327-ability-to-log-benchq-params-to-mlflow)
- Added dataclass tag and replaced __init__ with just the list of params

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.


[ZQS-1327]: https://zapatacomputing.atlassian.net/browse/ZQS-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ