### PR TITLE
Chore: Bump orquestra-quantum dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find_namespace:
 python_requires = >=3.8,!=3.9.7,<3.11
 
 install_requires =
-    orquestra-quantum==0.10.0
+    orquestra-quantum==0.11.0
     orquestra-vqa==0.8.0
     orquestra-qiskit==0.9.0
     orquestra-cirq @ git+https://github.com/zapatacomputing/orquestra-cirq


### PR DESCRIPTION
## Description
Dependency discrepancy - to run anything on benchq, orquestra-quantum==0.11 is required now.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
