### PR TITLE
Feat: Enable graph data reuse in workflows

### DIFF
--- a/src/benchq/resource_estimation/graph/customizable_pipelines.py
+++ b/src/benchq/resource_estimation/graph/customizable_pipelines.py
@@ -82,7 +82,7 @@ def create_extrapolated_graph_data_pipeline(
 ):
     # the architecture model doesn't matter for extrapolating graph data
     dummy_extrapolation_estimator = ExtrapolationResourceEstimator(
-        BASIC_ION_TRAP_ARCHITECTURE_MODEL(),
+        BASIC_ION_TRAP_ARCHITECTURE_MODEL,
         steps_to_extrapolate_from,
         decoder_model=decoder_model,
     )

--- a/src/benchq/resource_estimation/graph/extrapolation_estimator.py
+++ b/src/benchq/resource_estimation/graph/extrapolation_estimator.py
@@ -32,7 +32,7 @@ class ExtrapolationResourceEstimator(GraphResourceEstimator):
         self.steps_to_extrapolate_from = steps_to_extrapolate_from
         self.n_measurement_steps_fit_type = n_measurement_steps_fit_type
 
-    def _get_extrapolated_graph_data(
+    def get_extrapolated_graph_data(
         self,
         data: List[GraphData],
         program: QuantumProgram,
@@ -82,15 +82,12 @@ class ExtrapolationResourceEstimator(GraphResourceEstimator):
             steps_to_extrapolate_to=steps_to_extrapolate_to,
         )
 
-    def estimate_via_extrapolation(
+    def estimate_given_extrapolation_data(
         self,
         algorithm_description: AlgorithmImplementation,
-        data: List[GraphData],
+        extrapolated_info: ExtrapolatedGraphData,
     ):
         assert isinstance(algorithm_description.program, QuantumProgram)
-        extrapolated_info = self._get_extrapolated_graph_data(
-            data, algorithm_description.program
-        )
         resource_info = self.estimate_resources_from_graph_data(
             extrapolated_info, algorithm_description
         )


### PR DESCRIPTION
## Description

When using custom pipelines for multiple parameters, the same graph was regenerated many times. To avoid that we now can only generate a single graph and reuse it

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
