### PR TITLE
Double factorized block encoding cost

### DIFF
--- a/src/benchq/algorithms/ld_gsee.py
+++ b/src/benchq/algorithms/ld_gsee.py
@@ -55,7 +55,8 @@ def get_ff_ld_gsee_max_evolution_time(
         precision: The desired ground state energy precision. Corresponds to epsilon in
             the paper. Should use the same units as energy_gap.
 
-    Returns: The estimated number of iterations required by the FF-LD-GSEE algorithm.
+    Returns: The estimated maximum evolution time, given in the inverse units of
+        energy_gap and precision.
     """
     sigma = _get_sigma(alpha, energy_gap, square_overlap, precision)
     epsilon_1 = _get_epsilon_1(precision, square_overlap, sigma)

--- a/src/benchq/resource_estimation/openfermion_re.py
+++ b/src/benchq/resource_estimation/openfermion_re.py
@@ -157,7 +157,7 @@ def get_double_factorized_qpe_toffoli_and_qubit_cost(
     Returns:
         A tuple containing the number of Toffoli gates and number of logical qubits.
     """
-    tep_cost, total_cost, ancilla_cost = _get_double_factorized_qpe_info(
+    step_cost, total_cost, ancilla_cost = _get_double_factorized_qpe_info(
         h1,
         eri,
         threshold,
@@ -217,14 +217,10 @@ def get_double_factorized_block_encoding_toffoli_and_qubit_cost(
         bits_precision_rotation,
     )
 
-    # Now, we will remove the ancilla qubits in the energy register in QPE, and only add one using Guoming's algorithm.
-    # The number of steps in Heisenberg-Limited QPE, i.e., 2^m.
-    iters = np.ceil(np.pi * lam / (allowable_phase_estimation_error * 2))
-
-    # Number of control qubits in the energy register
-    m = 2 * np.ceil(np.log2(iters)) - 1
-
-    ancilla_cost = ancilla_cost - m + 1
+    # Remove all but one of the ancilla qubits in the QPE energy register.
+    iterations = np.ceil(np.pi * lam / (allowable_phase_estimation_error * 2))
+    num_qubits_energy_register = 2 * np.ceil(np.log2(iterations)) - 1
+    ancilla_cost = ancilla_cost - num_qubits_energy_register + 1
 
     return step_cost, ancilla_cost
 

--- a/src/benchq/resource_estimation/openfermion_re.py
+++ b/src/benchq/resource_estimation/openfermion_re.py
@@ -78,35 +78,23 @@ def get_single_factorized_qpe_toffoli_and_qubit_cost(
     )
     return sf_total_toffoli_cost, sf_logical_qubits
 
-
-def get_double_factorized_qpe_toffoli_and_qubit_cost(
+def _get_double_factorized_qpe_info(
     h1: np.ndarray,
     eri: np.ndarray,
     threshold: float,
     allowable_phase_estimation_error: float = 0.001,
     bits_precision_coefficients: int = 10,
     bits_precision_rotation: int = 20,
-) -> Tuple[int, int]:
-    """Get the number of Toffoli gates and logical qubits for double factorized QPE as
-    described in PRX Quantum 2, 030305.
-
-    Args:
-        h1: Matrix elements of the one-body operator that includes kinetic
-            energy operator and electorn-nuclear Coulomb operator.
-        eri: Four-dimensional array containing electron-repulsion
-            integrals.
-        threshold:
-        allowable_phase_estimation_error: Allowable error in phase estimation.
-            Corresponds to epsilon_QPE in the paper.
-        bits_precision_coefficients: The number of bits for the representation of
-            the coefficients. Corresponds to aleph_1 and aleph_2 in the paper.
-        bits_precision_rotations: The number of bits of precision for rotation angles.
-            Corresponds to beth in the paper.
+):
+    """Get information about the double factorized QPE algorithm.
+    
+    Args: See get_double_factorized_qpe_toffoli_and_qubit_cost.
 
     Returns:
-        A tuple containing the number of Toffoli gates and number of logical qubits.
+        Tuple containing the number of Toffoli gates per iteration, total number of
+            Tofolli gates, and total number of qubits.
     """
-
+    
     _validate_eri(eri)
     num_orb = h1.shape[0]
     num_spinorb = num_orb * 2
@@ -138,7 +126,108 @@ def get_double_factorized_qpe_toffoli_and_qubit_cost(
         verbose=False,
     )
 
+    return step_cost, total_cost, ancilla_cost
+
+def get_double_factorized_qpe_toffoli_and_qubit_cost(
+    h1: np.ndarray,
+    eri: np.ndarray,
+    threshold: float,
+    allowable_phase_estimation_error: float = 0.001,
+    bits_precision_coefficients: int = 10,
+    bits_precision_rotation: int = 20,
+) -> Tuple[int, int]:
+    """Get the number of Toffoli gates and logical qubits for double factorized QPE as
+    described in PRX Quantum 2, 030305.
+
+    Args:
+        h1: Matrix elements of the one-body operator that includes kinetic
+            energy operator and electorn-nuclear Coulomb operator.
+        eri: Four-dimensional array containing electron-repulsion
+            integrals.
+        threshold: Threshold for the factorization.
+        allowable_phase_estimation_error: Allowable error in phase estimation.
+            Corresponds to epsilon_QPE in the paper.
+        bits_precision_coefficients: The number of bits for the representation of
+            the coefficients. Corresponds to aleph_1 and aleph_2 in the paper.
+        bits_precision_rotations: The number of bits of precision for rotation angles.
+            Corresponds to beth in the paper.
+
+    Returns:
+        A tuple containing the number of Toffoli gates and number of logical qubits.
+    """
+    tep_cost, total_cost, ancilla_cost = _get_double_factorized_qpe_info(
+        h1,
+        eri,
+        threshold,
+        allowable_phase_estimation_error,
+        bits_precision_coefficients,
+        bits_precision_rotation,
+    )
+
     return total_cost, ancilla_cost
+
+def get_double_factorized_block_encoding_toffoli_and_qubit_cost(
+    h1: np.ndarray,
+    eri: np.ndarray,
+    threshold: float,
+    allowable_phase_estimation_error: float,
+    bits_precision_state_prep: int = 10,
+    bits_precision_rotation: int = 20,
+) -> Tuple[int, int]:
+    """Get the Toffoli and qubit cost for the double factorized block encoding.
+
+    Args:
+        h1: Matrix elements of the one-body operator that includes kinetic
+            energy operator and electorn-nuclear Coulomb operator.
+        eri: Four-dimensional array containing electron-repulsion
+            integrals.
+        threshold: Threshold for the factorization.
+        allowable_phase_estimation_error: Allowable error in phase estimation.
+            Corresponds to epsilon_QPE in the paper.
+        bits_precision_coefficients: The number of bits for the representation of
+            the coefficients. Corresponds to aleph_1 and aleph_2 in the paper.
+        bits_precision_rotations: The number of bits of precision for rotation angles.
+            Corresponds to beth in the paper.
+
+    Returns:
+        A tuple whose first element is the number of Toffolis required for a controlled
+            implementation of the block encoding, and whose second element is the number
+            of qubits required for the block encoding (not including the contol qubit).
+    """
+
+    # In the df.compute_cost(...) function below, we set dE = 1 since this input doesn't
+    # matter for us. We are only interested in the cost of implementing the quantum walk
+    # operator, not the cost of QPE which depends on dE. Recall, dE determines the
+    # precision of the QPE output which depends on the number of ancilla qubits in the
+    # energy register.
+
+    eri_rr, LR, L, Lxi = df.factorize(eri, threshold)
+    lam = compute_lambda_df(h1, eri_rr, LR)
+
+    allowable_phase_estimation_error = 1
+    (
+        step_cost,
+        total_cost,
+        ancilla_cost,
+    ) = _get_double_factorized_qpe_info(
+        h1,
+        eri,
+        threshold,
+        allowable_phase_estimation_error,
+        bits_precision_state_prep,
+        bits_precision_rotation,
+    )
+
+    # Now, we will remove the ancilla qubits in the energy register in QPE, and only add one using Guoming's algorithm.
+    # The number of steps in Heisenberg-Limited QPE, i.e., 2^m.
+    iters = np.ceil(np.pi * lam / (allowable_phase_estimation_error * 2))
+
+    # Number of control qubits in the energy register
+    m = 2 * np.ceil(np.log2(iters)) - 1
+
+    ancilla_cost = ancilla_cost - m
+
+    return step_cost, ancilla_cost
 
 
 def get_physical_cost(

--- a/src/benchq/resource_estimation/openfermion_re.py
+++ b/src/benchq/resource_estimation/openfermion_re.py
@@ -194,7 +194,8 @@ def get_double_factorized_block_encoding_toffoli_and_qubit_cost(
     Returns:
         A tuple whose first element is the number of Toffolis required for a controlled
             implementation of the block encoding, and whose second element is the number
-            of qubits required for the block encoding (not including the contol qubit).
+            of qubits required for the controlled block encoding (including the control
+            qubit).
     """
 
     # In the df.compute_cost(...) function below, we set dE = 1 since this input doesn't
@@ -223,7 +224,7 @@ def get_double_factorized_block_encoding_toffoli_and_qubit_cost(
     # Number of control qubits in the energy register
     m = 2 * np.ceil(np.log2(iters)) - 1
 
-    ancilla_cost = ancilla_cost - m
+    ancilla_cost = ancilla_cost - m + 1
 
     return step_cost, ancilla_cost
 

--- a/src/benchq/resource_estimation/openfermion_re.py
+++ b/src/benchq/resource_estimation/openfermion_re.py
@@ -78,6 +78,7 @@ def get_single_factorized_qpe_toffoli_and_qubit_cost(
     )
     return sf_total_toffoli_cost, sf_logical_qubits
 
+
 def _get_double_factorized_qpe_info(
     h1: np.ndarray,
     eri: np.ndarray,
@@ -87,14 +88,14 @@ def _get_double_factorized_qpe_info(
     bits_precision_rotation: int = 20,
 ):
     """Get information about the double factorized QPE algorithm.
-    
+
     Args: See get_double_factorized_qpe_toffoli_and_qubit_cost.
 
     Returns:
         Tuple containing the number of Toffoli gates per iteration, total number of
             Tofolli gates, and total number of qubits.
     """
-    
+
     _validate_eri(eri)
     num_orb = h1.shape[0]
     num_spinorb = num_orb * 2
@@ -127,6 +128,7 @@ def _get_double_factorized_qpe_info(
     )
 
     return step_cost, total_cost, ancilla_cost
+
 
 def get_double_factorized_qpe_toffoli_and_qubit_cost(
     h1: np.ndarray,
@@ -166,11 +168,11 @@ def get_double_factorized_qpe_toffoli_and_qubit_cost(
 
     return total_cost, ancilla_cost
 
+
 def get_double_factorized_block_encoding_toffoli_and_qubit_cost(
     h1: np.ndarray,
     eri: np.ndarray,
     threshold: float,
-    allowable_phase_estimation_error: float,
     bits_precision_state_prep: int = 10,
     bits_precision_rotation: int = 20,
 ) -> Tuple[int, int]:
@@ -205,11 +207,7 @@ def get_double_factorized_block_encoding_toffoli_and_qubit_cost(
     lam = compute_lambda_df(h1, eri_rr, LR)
 
     allowable_phase_estimation_error = 1
-    (
-        step_cost,
-        total_cost,
-        ancilla_cost,
-    ) = _get_double_factorized_qpe_info(
+    (step_cost, total_cost, ancilla_cost,) = _get_double_factorized_qpe_info(
         h1,
         eri,
         threshold,

--- a/tests/benchq/resource_estimation/test_openfermion_re.py
+++ b/tests/benchq/resource_estimation/test_openfermion_re.py
@@ -8,6 +8,7 @@ from benchq.problem_ingestion.molecule_instance_generation import (
     generate_hydrogen_chain_instance,
 )
 from benchq.resource_estimation.openfermion_re import (
+    get_double_factorized_block_encoding_toffoli_and_qubit_cost,
     get_double_factorized_qpe_toffoli_and_qubit_cost,
     get_physical_cost,
     get_single_factorized_qpe_toffoli_and_qubit_cost,
@@ -58,6 +59,29 @@ def test_df_qpe_logical_qubit_count_is_larger_than_number_of_spin_orbitals(
     assert num_qubits > 2 * eri_full.shape[0]
 
 
+@pytest.mark.parametrize(
+    "avas_atomic_orbitals,avas_minao",
+    [
+        (None, None),
+        (["H 1s", "H 2s"], "sto-3g"),
+    ],
+)
+def test_df_block_encoding_logical_qubit_count_is_larger_than_number_of_spin_orbitals(
+    avas_atomic_orbitals, avas_minao
+):
+    instance = generate_hydrogen_chain_instance(8)
+    instance.avas_atomic_orbitals = avas_atomic_orbitals
+    instance.avas_minao = avas_minao
+    mean_field_object = instance.get_active_space_meanfield_object()
+    h1, eri_full, _, _, _ = pyscf_to_cas(mean_field_object)
+
+    (
+        num_toffoli,
+        num_qubits,
+    ) = get_double_factorized_block_encoding_toffoli_and_qubit_cost(h1, eri_full, 1e-6)
+    assert num_qubits > 2 * eri_full.shape[0]
+
+
 def _get_asymmetric_hamiltonian():
     instance = generate_hydrogen_chain_instance(8)
     instance.avas_atomic_orbitals = ["H 1s", "H 2s"]
@@ -68,16 +92,22 @@ def _get_asymmetric_hamiltonian():
     return h1, eri_full
 
 
-def test_single_factorization_raises_exception_for_invalid_eri():
+def test_single_factorized_qpe_raises_exception_for_invalid_eri():
     h1, eri_full = _get_asymmetric_hamiltonian()
     with pytest.raises(ValueError):
         get_single_factorized_qpe_toffoli_and_qubit_cost(h1, eri_full, 20)
 
 
-def test_double_factorization_raises_exception_for_invalid_eri():
+def test_double_factorized_qpe_raises_exception_for_invalid_eri():
     h1, eri_full = _get_asymmetric_hamiltonian()
     with pytest.raises(ValueError):
         get_double_factorized_qpe_toffoli_and_qubit_cost(h1, eri_full, 1e-6)
+
+
+def test_double_factorized_block_encoding_raises_exception_for_invalid_eri():
+    h1, eri_full = _get_asymmetric_hamiltonian()
+    with pytest.raises(ValueError):
+        get_double_factorized_block_encoding_toffoli_and_qubit_cost(h1, eri_full, 1e-6)
 
 
 def test_physical_qubits_larger_than_logical_qubits():


### PR DESCRIPTION
## Description

For costing algorithms such as LD-GSEE, we need to obtain the cost of a single execution of the block-encoded Hamiltonian. This pull request addresses this by adding a function to get the cost (in terms of Toffoli gates and qubits) of the double factorized block encoding of electronic structure Hamiltonians.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
