### PR TITLE
Remove bottleneck from the FNO implementation 

### DIFF
--- a/src/benchq/problem_ingestion/molecule_instance_generation.py
+++ b/src/benchq/problem_ingestion/molecule_instance_generation.py
@@ -184,6 +184,8 @@ class ChemistryApplicationInstance:
             ]
 
         mean_field_object.mo_coeff = molecular_data.canonical_orbitals
+        molecular_data.n_orbitals = molecular_data.canonical_orbitals.shape[1]
+        molecular_data.n_qubits = 2 * molecular_data.n_orbitals
 
         return molecular_data
 

--- a/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
+++ b/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
@@ -80,6 +80,7 @@ def fno_water_instance():
     yield water_instance
 
 
+"""
 def test_get_occupied_and_active_indicies_with_FNO_frozen_core(fno_water_instance):
     fno_water_instance.freeze_core = True
 
@@ -119,7 +120,7 @@ def test_get_occupied_and_active_indicies_with_FNO_no_virtual_frozen_orbitals(
 
     assert len(occupied_indices) == 0
     assert len(active_indicies) < molecular_data.n_orbitals
-
+"""
 
 @pytest.mark.parametrize(
     "method", ["get_active_space_meanfield_object", "get_active_space_hamiltonian"]

--- a/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
+++ b/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
@@ -8,7 +8,8 @@ from benchq.problem_ingestion.molecule_instance_generation import (
 
 
 def _generate_avas_hydrogen_chain_instance(n_hydrogens):
-    avas_hydrogen_chain_instance = generate_hydrogen_chain_instance(n_hydrogens)
+    avas_hydrogen_chain_instance = generate_hydrogen_chain_instance(
+        n_hydrogens)
     avas_hydrogen_chain_instance.avas_atomic_orbitals = ["H 1s"]
     avas_hydrogen_chain_instance.avas_minao = "sto-3g"
     return avas_hydrogen_chain_instance
@@ -31,7 +32,8 @@ def test_hamiltonian_has_correct_number_of_qubits(
 
 def test_active_space_mean_field_object_has_valid_number_of_orbitals_with_avas_():
     number_of_hydrogens = 2
-    instance = generate_hydrogen_chain_instance(number_of_hydrogens=number_of_hydrogens)
+    instance = generate_hydrogen_chain_instance(
+        number_of_hydrogens=number_of_hydrogens)
     instance.avas_atomic_orbitals = ["H 1s", "H 2s"]
     instance.avas_minao = "sto-3g"
     total_number_of_orbitals = 2 * number_of_hydrogens
@@ -64,6 +66,23 @@ def test_mean_field_object_has_valid_default_scf_options():
 
 
 @pytest.fixture
+def water_instance():
+    water_instance = ChemistryApplicationInstance(
+        geometry=[
+            ("O", (0.000000, -0.075791844, 0.000000)),
+            ("H", (0.866811829, 0.601435779, 0.000000)),
+            ("H", (-0.866811829, 0.601435779, 0.000000)),
+        ],
+        basis="6-31g",
+        charge=0,
+        multiplicity=1,
+        # fno_percentage_occupation_number=0.9,
+    )
+
+    yield water_instance
+
+
+@pytest.fixture
 def fno_water_instance():
     water_instance = ChemistryApplicationInstance(
         geometry=[
@@ -80,50 +99,27 @@ def fno_water_instance():
     yield water_instance
 
 
-"""
-def test_get_occupied_and_active_indicies_with_FNO_frozen_core(fno_water_instance):
+def test_get_molecular_data_with_FNO_frozen_core(water_instance, fno_water_instance):
+    n_orbitals_no_fno_no_fzc = water_instance._get_molecular_data().n_orbitals
+
     fno_water_instance.freeze_core = True
 
-    (
-        molecular_data,
-        occupied_indices,
-        active_indicies,
-    ) = fno_water_instance.get_occupied_and_active_indicies_with_FNO()
+    molecular_data = fno_water_instance.get_molecular_data_with_FNO()
 
-    assert len(occupied_indices) == 1
-    assert len(active_indicies) < molecular_data.n_orbitals
+    assert molecular_data.n_orbitals < n_orbitals_no_fno_no_fzc
 
 
-def test_get_occupied_and_active_indicies_with_FNO_no_freeze_core(fno_water_instance):
-    fno_water_instance.freeze_core = False
+def test_get_molecular_data_with_FNO_no_frozen_core(water_instance, fno_water_instance):
+    n_orbitals_no_fno_no_fzc = water_instance._get_molecular_data().n_orbitals
 
-    (
-        molecular_data,
-        occupied_indices,
-        active_indicies,
-    ) = fno_water_instance.get_occupied_and_active_indicies_with_FNO()
+    molecular_data = fno_water_instance.get_molecular_data_with_FNO()
 
-    assert len(occupied_indices) == 0
-    assert len(active_indicies) < molecular_data.n_orbitals
+    assert molecular_data.n_orbitals < n_orbitals_no_fno_no_fzc
 
-
-def test_get_occupied_and_active_indicies_with_FNO_no_virtual_frozen_orbitals(
-    fno_water_instance,
-):
-    fno_water_instance.fno_percentage_occupation_number = 0.0
-
-    (
-        molecular_data,
-        occupied_indices,
-        active_indicies,
-    ) = fno_water_instance.get_occupied_and_active_indicies_with_FNO()
-
-    assert len(occupied_indices) == 0
-    assert len(active_indicies) < molecular_data.n_orbitals
-"""
 
 @pytest.mark.parametrize(
-    "method", ["get_active_space_meanfield_object", "get_active_space_hamiltonian"]
+    "method", ["get_active_space_meanfield_object",
+               "get_active_space_hamiltonian"]
 )
 def test_get_active_space_meanfield_object_raises_scf_convergence_error(method):
     instance = generate_hydrogen_chain_instance(2)

--- a/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
+++ b/tests/benchq/problem_ingestion/test_molecule_instance_generation.py
@@ -8,8 +8,7 @@ from benchq.problem_ingestion.molecule_instance_generation import (
 
 
 def _generate_avas_hydrogen_chain_instance(n_hydrogens):
-    avas_hydrogen_chain_instance = generate_hydrogen_chain_instance(
-        n_hydrogens)
+    avas_hydrogen_chain_instance = generate_hydrogen_chain_instance(n_hydrogens)
     avas_hydrogen_chain_instance.avas_atomic_orbitals = ["H 1s"]
     avas_hydrogen_chain_instance.avas_minao = "sto-3g"
     return avas_hydrogen_chain_instance
@@ -32,8 +31,7 @@ def test_hamiltonian_has_correct_number_of_qubits(
 
 def test_active_space_mean_field_object_has_valid_number_of_orbitals_with_avas_():
     number_of_hydrogens = 2
-    instance = generate_hydrogen_chain_instance(
-        number_of_hydrogens=number_of_hydrogens)
+    instance = generate_hydrogen_chain_instance(number_of_hydrogens=number_of_hydrogens)
     instance.avas_atomic_orbitals = ["H 1s", "H 2s"]
     instance.avas_minao = "sto-3g"
     total_number_of_orbitals = 2 * number_of_hydrogens
@@ -76,7 +74,6 @@ def water_instance():
         basis="6-31g",
         charge=0,
         multiplicity=1,
-        # fno_percentage_occupation_number=0.9,
     )
 
     yield water_instance
@@ -118,8 +115,7 @@ def test_get_molecular_data_with_FNO_no_frozen_core(water_instance, fno_water_in
 
 
 @pytest.mark.parametrize(
-    "method", ["get_active_space_meanfield_object",
-               "get_active_space_hamiltonian"]
+    "method", ["get_active_space_meanfield_object", "get_active_space_hamiltonian"]
 )
 def test_get_active_space_meanfield_object_raises_scf_convergence_error(method):
     instance = generate_hydrogen_chain_instance(2)


### PR DESCRIPTION
## Description

This PR removes the bottleneck of truncating the virtual space with FNO. 

In the current approach, the occupied and active indices are computed using the get_occupied_and_active_indicies_with_FNO() method, which  are used for computing molecular hamiltonians.
However, we take the entire MOs coefficient matrix for the integrals transformation which is very inefficient and consequently leads to memory issues for larger molecular complexes. 

To remove this bottleneck, only the truncated MO coefficient matrix is taken for integral transformation when FNO is selected for calculations.

## Please verify that you have completed the following steps

- [ ] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
