### PR TITLE
fix: make stim install_requires dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     juliacall~=0.9.10
     h5py~=3.8.0
     mlflow~=2.3.2
+    stim==1.10
 
 [options.packages.find]
 where = src
@@ -49,7 +50,6 @@ where = src
 dev =
     orquestra-python-dev
     # Used in tests
-    stim==1.10
     numba~=0.57.0
     benchq[pyscf]
     benchq[azure]


### PR DESCRIPTION
## Description

- Context: For GSC, benchq uses [Jabalizer](https://github.com/QSI-BAQS/Jabalizer.jl), and Jabalizer in turn [requires stim](https://github.com/QSI-BAQS/Jabalizer.jl/blob/main/CondaPkg.toml#L6). However, when orquestra tasks using GSC were executed on remote orquestra, stim either wasn't installed, or wasn't installed in a location where Jabalizer and the task had access to it, causing a very opaque error about juliacall not being installed (even if it was installed). This can be fixed by listing stim as a `PythonImport`, but that solution requires users to be aware of that issue, something which isn't obvious for someone who is just using benchq 
- To fix, we've made stim an `install_requires` dependency rather than just a `dev` dependency.
- This does not introduce any additional dependencies as the `dev` dependencies (including stim) were already required for full functionality

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
