### PR TITLE
Increasing maximum data qubit code distance

### DIFF
--- a/src/benchq/resource_estimation/_footprint_analysis.py
+++ b/src/benchq/resource_estimation/_footprint_analysis.py
@@ -238,7 +238,7 @@ def cost_estimator(
     for factory in iter_known_factories(
         physical_error_rate=physical_error_rate, num_toffoli=num_toffoli, num_t=num_t
     ):
-        for logical_data_qubit_distance in range(7, 35, 2):
+        for logical_data_qubit_distance in range(7, 101, 2):
             params = AlgorithmParameters(
                 physical_error_rate=physical_error_rate,
                 surface_code_cycle_time=surface_code_cycle_time,
@@ -261,4 +261,10 @@ def cost_estimator(
             ):
                 best_cost = cost
                 best_params = params
+
+    if best_cost is None:
+        raise RuntimeError(
+            "Failed to find parameters that yield an acceptable failure probability."
+        )
+
     return best_cost, best_params

--- a/tests/benchq/resource_estimation/test_openfermion_re.py
+++ b/tests/benchq/resource_estimation/test_openfermion_re.py
@@ -380,3 +380,10 @@ def test_default_scc_time():
     )
     assert cost.extra.physical_qubit_error_rate == 1e-3
     assert cost.extra.scc_time == 0.1e-6
+
+
+def test_get_physical_cost_supports_large_circuits():
+    n_logical_qubits = 4e3
+    n_toffoli = 1e12
+    resource_estimate = get_physical_cost(n_logical_qubits, n_toffoli)
+    assert resource_estimate.n_physical_qubits > n_logical_qubits


### PR DESCRIPTION
## Description

Right now, footprint analysis provided by `get_physical_cost` fails for large problems. This pull request addresses this by increasing the maximum code distance considered for logical data qubits. Additionally, if the physical costing fails, an exception will now be thrown to help users understand what has happened.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
