### PR TITLE
chore: Remove Python 3.11 upper bound and bump orquestra-* packages

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.8", "3.9"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: Coverage - Python ${{ matrix.python }} - ${{ matrix.os }}
 

--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           architecture: x64
 
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: Style - Python ${{ matrix.python }}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,13 +19,13 @@ include_package_data = True
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.8,!=3.9.7,<3.11
+python_requires = >=3.9,!=3.9.7
 
 install_requires =
-    orquestra-quantum==0.11.0
-    orquestra-vqa==0.8.0
-    orquestra-qiskit==0.12.0
-    orquestra-cirq==0.10.0
+    orquestra-quantum==0.12.0
+    orquestra-vqa==0.9.0
+    orquestra-qiskit==0.13.0
+    orquestra-cirq==0.11.0
     networkx>=2.8.7
     # Used to define and run Orquestra workflows
     orquestra-sdk[all]>=0.46.0


### PR DESCRIPTION
## Description

In order to install benchq on Python versions later than 3.10, we need to remove the Python upper bound.

This PR:
- Removes the <3.11 constraint.
- Updated `orquestra-*` packages to the first release that supports Python 3.11.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
