### PR TITLE
Feat: Add factory_count param to get_physical_cost and add distillation/computational qubit value for CostEstimate

### DIFF
--- a/src/benchq/resource_estimation/openfermion_re.py
+++ b/src/benchq/resource_estimation/openfermion_re.py
@@ -246,6 +246,7 @@ def get_physical_cost(
     routing_overhead_proportion=0.5,
     hardware_failure_tolerance=1e-3,
     decoder_model=None,
+    factory_count: int = 4,
 ) -> OpenFermionResourceInfo:
     """Get the estimated resources for single factorized QPE as described in PRX Quantum
     2, 030305.
@@ -265,6 +266,7 @@ def get_physical_cost(
         surface_code_cycle_time=architecture_model.surface_code_cycle_time_in_seconds,
         routing_overhead_proportion=routing_overhead_proportion,
         hardware_failure_tolerance=hardware_failure_tolerance,
+        factory_count=factory_count,
     )
 
     decoder_info = get_decoder_info(


### PR DESCRIPTION
## Description

https://zapatacomputing.atlassian.net/browse/DTA2-304

1. Users would like to be able to choose the number of distillation factories that are running in parallel so that they can trade off the number of qubits and the runtime
2. Users would like to be able to view the values of n_physical_qubits_used_for_clifford_circuit and n_physical_qubits_used_for_distillation in the output of get_physical_cost

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
