### PR TITLE
DTA2 176 actual decoder ests updates (minor changes)

### DIFF
--- a/src/benchq/decoder_modeling/decoder_resource_estimator.py
+++ b/src/benchq/decoder_modeling/decoder_resource_estimator.py
@@ -42,8 +42,7 @@ def get_decoder_info(
                 * 1e-18
             )
             decoder_power_in_watts = (
-                2
-                * n_logical_qubits
+                n_logical_qubits
                 * decoder_model.power_in_nanowatts(code_distance)
                 * 1e-9
             )

--- a/src/benchq/resource_estimators/graph_estimators/graph_estimator.py
+++ b/src/benchq/resource_estimators/graph_estimators/graph_estimator.py
@@ -307,6 +307,11 @@ class GraphResourceEstimator:
 
         magic_state_factory_iterator = iter(self.magic_state_factory_iterator)
 
+        # Approximate the number of logical qubits for the bus architecture
+        # TODO: We should update this to accommodate the space vs time optimal compilation
+        # once we have the substrate scheduler properly implemented.
+        n_logical_qubits = 2 * graph_data.max_graph_degree
+
         while True:
             magic_state_factory_found = False
             for magic_state_factory in magic_state_factory_iterator:
@@ -352,8 +357,7 @@ class GraphResourceEstimator:
                 return GraphResourceInfo(
                     code_distance=-1,
                     logical_error_rate=1.0,
-                    # estimate the number of logical qubits using max node degree
-                    n_logical_qubits=graph_data.max_graph_degree,
+                    n_logical_qubits=n_logical_qubits,
                     total_time_in_seconds=0.0,
                     n_physical_qubits=0,
                     magic_state_factory_name="No MagicStateFactory Found",
@@ -426,14 +430,13 @@ class GraphResourceEstimator:
             self.decoder_model,
             code_distance,
             space_time_volume,
-            graph_data.max_graph_degree,
+            n_logical_qubits,
         )
 
         return GraphResourceInfo(
             code_distance=code_distance,
             logical_error_rate=total_logical_error_rate,
-            # estimate the number of logical qubits using max node degree
-            n_logical_qubits=graph_data.max_graph_degree,
+            n_logical_qubits=n_logical_qubits,
             total_time_in_seconds=total_time_in_seconds,
             n_physical_qubits=n_physical_qubits,
             magic_state_factory_name=magic_state_factory.name,

--- a/src/benchq/resource_estimators/graph_estimators/graph_estimator.py
+++ b/src/benchq/resource_estimators/graph_estimators/graph_estimator.py
@@ -308,7 +308,7 @@ class GraphResourceEstimator:
         magic_state_factory_iterator = iter(self.magic_state_factory_iterator)
 
         # Approximate the number of logical qubits for the bus architecture
-        # TODO: We should update this to accommodate the space vs time optimal compilation
+        # TODO: Update to accommodate the space vs time optimal compilation
         # once we have the substrate scheduler properly implemented.
         n_logical_qubits = 2 * graph_data.max_graph_degree
 

--- a/tests/benchq/decoder_modeling/test_decoder_resource_estimator.py
+++ b/tests/benchq/decoder_modeling/test_decoder_resource_estimator.py
@@ -51,7 +51,7 @@ def test_if_decoder_equations_have_changed():
     decoder_info = get_decoder_info(BASIC_SC_ARCHITECTURE_MODEL, decoder_model, 4, 2, 3)
     target_info = DecoderInfo(
         total_energy_in_joules=4e-12,
-        power_in_watts=1.2e-04,
+        power_in_watts=6e-05,
         area_in_micrometers_squared=600.0,
         max_decodable_distance=15,
     )

--- a/tests/benchq/resource_estimation/graph_estimators/test_graph_estimator.py
+++ b/tests/benchq/resource_estimation/graph_estimators/test_graph_estimator.py
@@ -94,31 +94,31 @@ def test_resource_estimations_returns_results_for_different_architectures(
             QuantumProgram(
                 [Circuit([H(0), RZ(np.pi / 4)(0), CNOT(0, 1)])], 1, lambda x: [0]
             ),
-            {"n_measurement_steps": 3, "n_nodes": 3, "n_logical_qubits": 2},
+            {"n_measurement_steps": 3, "n_nodes": 3, "n_logical_qubits": 4},
         ),
         (
             get_program_from_circuit(
                 Circuit([RX(np.pi / 4)(0), RY(np.pi / 4)(0), CNOT(0, 1)])
             ),
-            {"n_measurement_steps": 4, "n_nodes": 4, "n_logical_qubits": 2},
+            {"n_measurement_steps": 4, "n_nodes": 4, "n_logical_qubits": 4},
         ),
         (
             get_program_from_circuit(
                 Circuit([H(0)] + [CNOT(i, i + 1) for i in range(3)])
             ),
-            {"n_measurement_steps": 4, "n_nodes": 4, "n_logical_qubits": 3},
+            {"n_measurement_steps": 4, "n_nodes": 4, "n_logical_qubits": 6},
         ),
         (
             get_program_from_circuit(
                 Circuit([H(0)] + [CNOT(i, i + 1) for i in range(3)] + [T(1), T(2)])
             ),
-            {"n_measurement_steps": 6, "n_nodes": 6, "n_logical_qubits": 5},
+            {"n_measurement_steps": 6, "n_nodes": 6, "n_logical_qubits": 10},
         ),
         (
             get_program_from_circuit(
                 Circuit([H(0), T(0), CNOT(0, 1), T(2), CNOT(2, 3)])
             ),
-            {"n_measurement_steps": 3, "n_nodes": 3, "n_logical_qubits": 2},
+            {"n_measurement_steps": 3, "n_nodes": 3, "n_logical_qubits": 4},
         ),
     ],
 )


### PR DESCRIPTION
## Description

This PR modifies the way that the logical qubit count is used in both graph state compilation resource estimates and decoder resource estimates. This was needed because the graph state compilation resource estimates were not consistently using 2*max_graph_degree (an approximation that will be updated in future pull requests) and the decoder resource estimates contained a bug where the number of logical qubits was being multiplied by two (a vestige from when all the BenchQ resource estimates assumed the bus architecture of GSC).

The implemented solution was to:
- compute the n_logical_qubit approximation once within the `estimate_resources_from_graph_data()` method and then use that value throughout
- remove the x2 from the decoder resource estimates so that it now accommodates any architecture (as long as the appropriate logical qubit number is supplied)