### PR TITLE
Fix: Change litinsky factory to return based on error rate, not architecture type

### DIFF
--- a/src/benchq/magic_state_distillation/litinski_factories.py
+++ b/src/benchq/magic_state_distillation/litinski_factories.py
@@ -9,67 +9,68 @@ from .magic_state_factory import MagicStateFactory
 
 _ALLOWED_PHYSICAL_ERROR_RATES = (1e-3, 1e-4)
 
+_ERROR_RATE_FACTORY_MAPPING = {
+    1e-4: (
+        MagicStateFactory("(15-to-1)_17,7,7", 4.5e-8, (72, 64), 4620, 42.6),
+        MagicStateFactory(
+            "(15-to-1)^6_15,5,5 x (20-to-4)_23,11,13",
+            1.4e-10,
+            (387, 155),
+            43300,
+            130,
+        ),
+        MagicStateFactory(
+            "(15-to-1)^4_13,5,5 x (20-to-4)_27,13,15",
+            2.6e-11,
+            (382, 142),
+            46800,
+            157,
+            n_t_gates_produced_per_distillation=1,
+        ),
+        MagicStateFactory(
+            "(15-to-1)^6_11,5,5 x (15-to-1)_25,11,11",
+            2.7e-12,
+            (279, 117),
+            30700,
+            82.5,
+        ),
+        MagicStateFactory(
+            "(15-to-1)^6_13,5,5 x (15-to-1)_29,11,13",
+            3.3e-14,
+            (292, 138),
+            39100,
+            97.5,
+        ),
+        MagicStateFactory(
+            "(15-to-1)^6_17,7,7 x (15-to-1)_41,17,17",
+            4.5e-20,
+            (426, 181),
+            73400,
+            128,
+        ),
+    ),
+    1e-3: (
+        MagicStateFactory("(15-to-1)_7,3,3", 4.4e-8, (30, 27), 810, 18.1),
+        MagicStateFactory("(15-to-1)_9,3,3", 9.3e-10, (38, 30), 1150, 18.1),
+        MagicStateFactory("(15-to-1)_11,5,5", 1.9e-11, (47, 44), 2070, 30),
+        MagicStateFactory(
+            "(15-to-1)^4_9,3,3 x (20-to-4)_15,7,9",
+            2.4e-15,
+            (221, 96),
+            16400,
+            90.3,
+            n_t_gates_produced_per_distillation=4,
+        ),
+        MagicStateFactory(
+            "(15-to-1)^4_9,3,3 x (15-to-1)_25,9,9", 6.3e-25, (193, 96), 18600, 67.8
+        ),
+    ),
+}
+
 
 def iter_litinski_factories(
     architecture_model: BasicArchitectureModel,
 ) -> Iterable[MagicStateFactory]:
     assert architecture_model.physical_qubit_error_rate in _ALLOWED_PHYSICAL_ERROR_RATES
 
-    error_rate_to_factory_dict = {
-        1e-4: (
-            MagicStateFactory("(15-to-1)_17,7,7", 4.5e-8, (72, 64), 4620, 42.6),
-            MagicStateFactory(
-                "(15-to-1)^6_15,5,5 x (20-to-4)_23,11,13",
-                1.4e-10,
-                (387, 155),
-                43300,
-                130,
-            ),
-            MagicStateFactory(
-                "(15-to-1)^4_13,5,5 x (20-to-4)_27,13,15",
-                2.6e-11,
-                (382, 142),
-                46800,
-                157,
-                n_t_gates_produced_per_distillation=1,
-            ),
-            MagicStateFactory(
-                "(15-to-1)^6_11,5,5 x (15-to-1)_25,11,11",
-                2.7e-12,
-                (279, 117),
-                30700,
-                82.5,
-            ),
-            MagicStateFactory(
-                "(15-to-1)^6_13,5,5 x (15-to-1)_29,11,13",
-                3.3e-14,
-                (292, 138),
-                39100,
-                97.5,
-            ),
-            MagicStateFactory(
-                "(15-to-1)^6_17,7,7 x (15-to-1)_41,17,17",
-                4.5e-20,
-                (426, 181),
-                73400,
-                128,
-            ),
-        ),
-        1e-3: (
-            MagicStateFactory("(15-to-1)_7,3,3", 4.4e-8, (30, 27), 810, 18.1),
-            MagicStateFactory("(15-to-1)_9,3,3", 9.3e-10, (38, 30), 1150, 18.1),
-            MagicStateFactory("(15-to-1)_11,5,5", 1.9e-11, (47, 44), 2070, 30),
-            MagicStateFactory(
-                "(15-to-1)^4_9,3,3 x (20-to-4)_15,7,9",
-                2.4e-15,
-                (221, 96),
-                16400,
-                90.3,
-                n_t_gates_produced_per_distillation=4,
-            ),
-            MagicStateFactory(
-                "(15-to-1)^4_9,3,3 x (15-to-1)_25,9,9", 6.3e-25, (193, 96), 18600, 67.8
-            ),
-        ),
-    }
-    return error_rate_to_factory_dict[architecture_model.physical_qubit_error_rate]
+    return _ERROR_RATE_FACTORY_MAPPING[architecture_model.physical_qubit_error_rate]

--- a/src/benchq/magic_state_distillation/litinski_factories.py
+++ b/src/benchq/magic_state_distillation/litinski_factories.py
@@ -2,108 +2,74 @@ from functools import singledispatch
 from typing import Iterable
 
 from benchq.quantum_hardware_modeling.hardware_architecture_models import (
-    DetailedIonTrapModel,
-    IONTrapModel,
-    SCModel,
+    BasicArchitectureModel,
 )
 
 from .magic_state_factory import MagicStateFactory
 
-
-@singledispatch
-def iter_litinski_factories(architecture_model) -> Iterable[MagicStateFactory]:
-    raise NotImplementedError(
-        f"No MagicStateFactorys known for type model {architecture_model}"
-    )
+_ALLOWED_PHYSICAL_ERROR_RATES = (1e-3, 1e-4)
 
 
-@iter_litinski_factories.register
-def iter_litinski_factories_for_ion_traps(
-    _architecture_model: IONTrapModel,
+def iter_litinski_factories(
+    architecture_model: BasicArchitectureModel,
 ) -> Iterable[MagicStateFactory]:
-    return [
-        MagicStateFactory("(15-to-1)_7,3,3", 4.4e-8, (30, 27), 810, 18.1),
-        MagicStateFactory("(15-to-1)_9,3,3", 9.3e-10, (38, 30), 1150, 18.1),
-        MagicStateFactory("(15-to-1)_11,5,5", 1.9e-11, (47, 44), 2070, 30),
-        MagicStateFactory(
-            "(15-to-1)^4_9,3,3 x (20-to-4)_15,7,9",
-            2.4e-15,
-            (221, 96),
-            16400,
-            90.3,
-            n_t_gates_produced_per_distillation=4,
-        ),
-        MagicStateFactory(
-            "(15-to-1)^4_9,3,3 x (15-to-1)_25,9,9", 6.3e-25, (193, 96), 18600, 67.8
-        ),
-    ]
+    assert architecture_model.physical_qubit_error_rate in _ALLOWED_PHYSICAL_ERROR_RATES
 
-
-# this can be combined with the above function, when we upgrade to python 3.11
-# and union types are supported by singledispatch.
-# https://github.com/python/cpython/issues/90172
-@iter_litinski_factories.register
-def iter_litinski_factories_for_detailed_ion_traps(
-    _architecture_model: DetailedIonTrapModel,
-) -> Iterable[MagicStateFactory]:
-    return [
-        MagicStateFactory("(15-to-1)_7,3,3", 4.4e-8, (30, 27), 810, 18.1),
-        MagicStateFactory("(15-to-1)_9,3,3", 9.3e-10, (38, 30), 1150, 18.1),
-        MagicStateFactory("(15-to-1)_11,5,5", 1.9e-11, (47, 44), 2070, 30),
-        MagicStateFactory(
-            "(15-to-1)^4_9,3,3 x (20-to-4)_15,7,9",
-            2.4e-15,
-            (221, 96),
-            16400,
-            90.3,
-            n_t_gates_produced_per_distillation=4,
+    error_rate_to_factory_dict = {
+        1e-4: (
+            MagicStateFactory("(15-to-1)_17,7,7", 4.5e-8, (72, 64), 4620, 42.6),
+            MagicStateFactory(
+                "(15-to-1)^6_15,5,5 x (20-to-4)_23,11,13",
+                1.4e-10,
+                (387, 155),
+                43300,
+                130,
+            ),
+            MagicStateFactory(
+                "(15-to-1)^4_13,5,5 x (20-to-4)_27,13,15",
+                2.6e-11,
+                (382, 142),
+                46800,
+                157,
+                n_t_gates_produced_per_distillation=1,
+            ),
+            MagicStateFactory(
+                "(15-to-1)^6_11,5,5 x (15-to-1)_25,11,11",
+                2.7e-12,
+                (279, 117),
+                30700,
+                82.5,
+            ),
+            MagicStateFactory(
+                "(15-to-1)^6_13,5,5 x (15-to-1)_29,11,13",
+                3.3e-14,
+                (292, 138),
+                39100,
+                97.5,
+            ),
+            MagicStateFactory(
+                "(15-to-1)^6_17,7,7 x (15-to-1)_41,17,17",
+                4.5e-20,
+                (426, 181),
+                73400,
+                128,
+            ),
         ),
-        MagicStateFactory(
-            "(15-to-1)^4_9,3,3 x (15-to-1)_25,9,9", 6.3e-25, (193, 96), 18600, 67.8
+        1e-3: (
+            MagicStateFactory("(15-to-1)_7,3,3", 4.4e-8, (30, 27), 810, 18.1),
+            MagicStateFactory("(15-to-1)_9,3,3", 9.3e-10, (38, 30), 1150, 18.1),
+            MagicStateFactory("(15-to-1)_11,5,5", 1.9e-11, (47, 44), 2070, 30),
+            MagicStateFactory(
+                "(15-to-1)^4_9,3,3 x (20-to-4)_15,7,9",
+                2.4e-15,
+                (221, 96),
+                16400,
+                90.3,
+                n_t_gates_produced_per_distillation=4,
+            ),
+            MagicStateFactory(
+                "(15-to-1)^4_9,3,3 x (15-to-1)_25,9,9", 6.3e-25, (193, 96), 18600, 67.8
+            ),
         ),
-    ]
-
-
-@iter_litinski_factories.register
-def iter_litinski_factories_for_sc(
-    _architecture_model: SCModel,
-) -> Iterable[MagicStateFactory]:
-    return [
-        MagicStateFactory("(15-to-1)_17,7,7", 4.5e-8, (72, 64), 4620, 42.6),
-        MagicStateFactory(
-            "(15-to-1)^6_15,5,5 x (20-to-4)_23,11,13",
-            1.4e-10,
-            (387, 155),
-            43300,
-            130,
-        ),
-        MagicStateFactory(
-            "(15-to-1)^4_13,5,5 x (20-to-4)_27,13,15",
-            2.6e-11,
-            (382, 142),
-            46800,
-            157,
-            n_t_gates_produced_per_distillation=1,
-        ),
-        MagicStateFactory(
-            "(15-to-1)^6_11,5,5 x (15-to-1)_25,11,11",
-            2.7e-12,
-            (279, 117),
-            30700,
-            82.5,
-        ),
-        MagicStateFactory(
-            "(15-to-1)^6_13,5,5 x (15-to-1)_29,11,13",
-            3.3e-14,
-            (292, 138),
-            39100,
-            97.5,
-        ),
-        MagicStateFactory(
-            "(15-to-1)^6_17,7,7 x (15-to-1)_41,17,17",
-            4.5e-20,
-            (426, 181),
-            73400,
-            128,
-        ),
-    ]
+    }
+    return error_rate_to_factory_dict[architecture_model.physical_qubit_error_rate]

--- a/src/benchq/magic_state_distillation/litinski_factories.py
+++ b/src/benchq/magic_state_distillation/litinski_factories.py
@@ -10,7 +10,7 @@ from .magic_state_factory import MagicStateFactory
 _ALLOWED_PHYSICAL_ERROR_RATES = (1e-3, 1e-4)
 
 _ERROR_RATE_FACTORY_MAPPING = {
-    1e-4: (
+    1e-3: (
         MagicStateFactory("(15-to-1)_17,7,7", 4.5e-8, (72, 64), 4620, 42.6),
         MagicStateFactory(
             "(15-to-1)^6_15,5,5 x (20-to-4)_23,11,13",
@@ -49,7 +49,7 @@ _ERROR_RATE_FACTORY_MAPPING = {
             128,
         ),
     ),
-    1e-3: (
+    1e-4: (
         MagicStateFactory("(15-to-1)_7,3,3", 4.4e-8, (30, 27), 810, 18.1),
         MagicStateFactory("(15-to-1)_9,3,3", 9.3e-10, (38, 30), 1150, 18.1),
         MagicStateFactory("(15-to-1)_11,5,5", 1.9e-11, (47, 44), 2070, 30),

--- a/tests/benchq/magic_state_distillation/test_litinski_factories.py
+++ b/tests/benchq/magic_state_distillation/test_litinski_factories.py
@@ -1,3 +1,6 @@
+import dataclasses
+from dataclasses import replace
+
 import pytest
 
 from benchq.magic_state_distillation.litinski_factories import iter_litinski_factories
@@ -13,6 +16,7 @@ from benchq.quantum_hardware_modeling.hardware_architecture_models import (
     [
         BASIC_ION_TRAP_ARCHITECTURE_MODEL,
         BASIC_SC_ARCHITECTURE_MODEL,
+        DetailedIonTrapModel(),
     ],
 )
 def test_factory_properties_are_correct(architecture_model):
@@ -24,3 +28,11 @@ def test_factory_properties_are_correct(architecture_model):
         assert factory.qubits > 0
         assert factory.distillation_time_in_cycles > 0
         assert factory.n_t_gates_produced_per_distillation >= 1
+
+
+def test_factory_based_on_err_rate():
+    ion = BASIC_ION_TRAP_ARCHITECTURE_MODEL
+    cs = BASIC_SC_ARCHITECTURE_MODEL
+    cs = replace(cs, physical_qubit_error_rate=1e-4)
+
+    assert iter_litinski_factories(cs) == iter_litinski_factories(ion)

--- a/tests/benchq/resource_estimation/graph_estimators/test_graph_estimator.py
+++ b/tests/benchq/resource_estimation/graph_estimators/test_graph_estimator.py
@@ -8,6 +8,9 @@ from orquestra.quantum.circuits import CNOT, RX, RY, RZ, Circuit, H, T
 from benchq.algorithms.data_structures import AlgorithmImplementation, ErrorBudget
 from benchq.compilation import get_ruby_slippers_compiler
 from benchq.decoder_modeling import DecoderModel
+from benchq.magic_state_distillation.litinski_factories import (
+    _ERROR_RATE_FACTORY_MAPPING,
+)
 from benchq.problem_embeddings.quantum_program import (
     QuantumProgram,
     get_program_from_circuit,
@@ -185,7 +188,9 @@ def test_better_architecture_does_not_require_more_resources(
     high_noise_resource_estimates = get_custom_resource_estimation(
         algorithm_implementation,
         estimator=GraphResourceEstimator(
-            high_noise_architecture_model, optimization=optimization
+            high_noise_architecture_model,
+            optimization=optimization,
+            magic_state_factory_iterator=_ERROR_RATE_FACTORY_MAPPING[1e-4],
         ),
         transformers=transformers,
     )


### PR DESCRIPTION
## Description

Include description of feature this PR introduces or a bug that it fixes. Include the following information:
(https://zapatacomputing.atlassian.net/browse/DTA2-336)
Litinsky factory was returning based on input architecture type, not error rate. If someone changed/customised error_rate, they would get invalid fatories

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
