### PR TITLE
Fix: Update 'tStates' for Azure QRE error budget

### DIFF
--- a/src/benchq/resource_estimators/azure_estimator.py
+++ b/src/benchq/resource_estimators/azure_estimator.py
@@ -67,7 +67,7 @@ def azure_estimator(
         ] = algorithm.error_budget.transpilation_failure_tolerance
         remaining_error = algorithm.error_budget.hardware_failure_tolerance
         azure_error_budget["logical"] = remaining_error / 2
-        azure_error_budget["tstates"] = remaining_error / 2
+        azure_error_budget["tStates"] = remaining_error / 2
     if use_full_circuit:
         circuit = algorithm.program.full_circuit
         return _estimate_resources_for_circuit(hw_model, circuit, azure_error_budget)


### PR DESCRIPTION
## Description
Fixes #145 

Currently, for the Azure QRE integration, the error budget is being set to `azure_error_budget["tstates"]`. This results in an error because the error budget is expecting `tStates`.

Due to the integration with Azure QRE, automated test cases for validation is not easily done. 

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
