### PR TITLE
Fix: Example 3 Azure estimator paramter name

### DIFF
--- a/examples/ex_3_packages_comparison.py
+++ b/examples/ex_3_packages_comparison.py
@@ -78,7 +78,6 @@ def main():
     with measure_time() as t_info:
         azure_resource_estimates = azure_estimator(
             algorithm,
-            architecture_model=architecture_model,
         )
 
     print("Resource estimation time with Azure:", t_info.total)


### PR DESCRIPTION
## Description
Fixes #154 

Currently, ex_3_packages_comparison.py is calling the azure_estimator and passing in `architecture_model=architecture_model`. However, the azure_estimator is expecting the parameter `hw_model`. 

To correct this behavior, there are two options:
1.) The first option is to change the parameter in the call to azure_estimator to `hw_model=architecture_model`. However, the azure_estimator does not currently handle hardware models. This is shown to the user in the following warning: 
`src/benchq/resource_estimators/azure_estimator.py:59: UserWarning: Supplying hardware model to AzureResourceEstimator is currently broken.`

Running a test using `hw_model` results in:
```
RuntimeError: Cannot retrieve results as job execution failed (IOError: cannot parse JSON: 'missing fields `oneQubitMeasurementTime`, `tGateErrorRate`, `oneQubitMeasurementErrorRate` at line 1 column 294')
```

2.) The second option is to not pass the `architecture_model` to `azure_estimator`. At least until `hw_model` is working properly, I think this is the best option and the one implemented in this PR.


**NOTE**: In order to use the Azure estimator, please include fix seen in PR #153 . Without this fix, the Azure estimator will not run.

As this is dealing with an example and the Azure QRE integration, an automated test is not feasible.

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
