### PR TITLE
fix: bump sdk version to avoid artifactfuture typing issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     orquestra-opt==0.10.0
     networkx>=2.8.7
     # Used to define and run Orquestra workflows
-    orquestra-sdk[all]>=0.46.0
+    orquestra-sdk[all]>=0.63.0
     matplotlib>=3.6
     numpy>=1.20
     more-itertools~=9.1.0


### PR DESCRIPTION
## Description

When I made my last PR to benchq. I Brian Goldsmith found that one of the examples had broken.
This was due to a bug in the sdk that was fixed in version 0.63.
This PR bumps the version of orquestra-sdk to require versions that have this fix.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
