### PR TITLE
Disable autoloading of ipython extension

### DIFF
--- a/src/benchq/compilation/graph_states/initialize_julia.py
+++ b/src/benchq/compilation/graph_states/initialize_julia.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 import juliapkg
@@ -52,6 +53,13 @@ if curr_deps != dependency_dict:
 
 juliapkg.resolve()
 
+# Disable autoloading of the IPython extension unless the user explicitly requests it.
+# Context: if IPython.display.set_matplotlib_formats has been called, then the
+# autoloading of the IPython extension seems to cause the program to exit or hang. (The
+# set_matplotlib_formats function gets called, for example, when certain pyLIQTR modules
+#  are imported.)
+if "PYTHON_JULIACALL_AUTOLOAD_IPYTHON_EXTENSION" not in os.environ:
+    os.environ["PYTHON_JULIACALL_AUTOLOAD_IPYTHON_EXTENSION"] = "no"
 
 # Put this import second because it can install julia automatically and we don't
 # want to install julia twice if the julia version that juliacall finds is different

--- a/src/benchq/compilation/graph_states/initialize_julia.py
+++ b/src/benchq/compilation/graph_states/initialize_julia.py
@@ -57,7 +57,7 @@ juliapkg.resolve()
 # Context: if IPython.display.set_matplotlib_formats has been called, then the
 # autoloading of the IPython extension seems to cause the program to exit or hang. (The
 # set_matplotlib_formats function gets called, for example, when certain pyLIQTR modules
-#  are imported.)
+# are imported.)
 if "PYTHON_JULIACALL_AUTOLOAD_IPYTHON_EXTENSION" not in os.environ:
     os.environ["PYTHON_JULIACALL_AUTOLOAD_IPYTHON_EXTENSION"] = "no"
 


### PR DESCRIPTION
@pediejo encountered an issue where the following sequence of imports would cause the program to terminate or hang. The workaround provided by this PR seems to solve this issue.
 
```python
from pyLIQTR.qubitization.qsvt_dynamics import qsvt_dynamics
from benchq.algorithms.data_structures import AlgorithmImplementation
print("Imports successful")
```