### PR TITLE
Removed factor of 6 from time_per_circuit_in_seconds

### DIFF
--- a/src/benchq/resource_estimators/graph_estimator.py
+++ b/src/benchq/resource_estimators/graph_estimator.py
@@ -467,7 +467,7 @@ class GraphResourceEstimator:
 
         # get time to get a single shot
         time_per_circuit_in_seconds = (
-            6 * num_cycles * hw_model.surface_code_cycle_time_in_seconds
+            num_cycles * hw_model.surface_code_cycle_time_in_seconds
         )
 
         total_time_in_seconds = (


### PR DESCRIPTION
## Description

Summary:
The issue involves removing the factor of 6 from BenchQ to correct inconsistencies in the runtime calculation.

Context:
The factor of six needs to be removed to align the equations with the updated terminology. For details, see [here](https://zapatacomputing.atlassian.net/browse/DTA2-502).

Implemented solution:
Removed factor of 6 from time_per_circuit_in_seconds in graph_estimator.py in line 469

        time_per_circuit_in_seconds = (
            6 * num_cycles * hw_model.surface_code_cycle_time_in_seconds
        )
