### PR TITLE
Remove factor of 6

### DIFF
--- a/src/benchq/resource_estimators/graph_estimator.py
+++ b/src/benchq/resource_estimators/graph_estimator.py
@@ -467,7 +467,7 @@ class GraphResourceEstimator:
 
         # get time to get a single shot
         time_per_circuit_in_seconds = (
-            6 * num_cycles * hw_model.surface_code_cycle_time_in_seconds
+            num_cycles * hw_model.surface_code_cycle_time_in_seconds
         )
 
         total_time_in_seconds = (


### PR DESCRIPTION
## Description

Summary:
The issue involves removing the factor of 6 from BenchQ to correct inconsistencies in the runtime calculation.

Context:
This factor of six is because the syndrome extraction circuits have depth 6 when assuming direct physical ability to initialise and readout qubits in the X-basis. There is a discrepancy in the terminology used, which stems from the historical use of gate_time instead of surface_code_cycle_time.  The factor of six needs to be removed to align the equations with the updated terminology. 

Implemented solution:
Removed factor of 6 from time_per_circuit_in_seconds in graph_estimator.py in line 469

    time_per_circuit_in_seconds = (
        6 * num_cycles * hw_model.surface_code_cycle_time_in_seconds
    )
